### PR TITLE
Fix correctness bugs surfaced in code review

### DIFF
--- a/manify/__init__.py
+++ b/manify/__init__.py
@@ -8,9 +8,7 @@ if os.getenv("BEARTYPE_ENABLE", "false").lower() == "true":
     from jaxtyping import install_import_hook
 
     install_import_hook("manify", "beartype.beartype")
-    print(
-        "Beartype import hook installed for Manify. Will use beartype for type checking."
-    )
+    print("Beartype import hook installed for Manify. Will use beartype for type checking.")
 
 from manify.clustering import RiemannianFuzzyKMeans
 from manify.curvature_estimation import (

--- a/manify/__init__.py
+++ b/manify/__init__.py
@@ -1,23 +1,42 @@
 """Manify: A Python Library for Learning Non-Euclidean Representations."""
 
 import os
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
 if os.getenv("BEARTYPE_ENABLE", "false").lower() == "true":
     from jaxtyping import install_import_hook
 
     install_import_hook("manify", "beartype.beartype")
-    print("Beartype import hook installed for Manify. Will use beartype for type checking.")
+    print(
+        "Beartype import hook installed for Manify. Will use beartype for type checking."
+    )
 
 from manify.clustering import RiemannianFuzzyKMeans
-from manify.curvature_estimation import delta_hyperbolicity, greedy_signature_selection, sectional_curvature
+from manify.curvature_estimation import (
+    delta_hyperbolicity,
+    greedy_signature_selection,
+    sectional_curvature,
+)
 from manify.embedders import CoordinateLearning, ProductSpaceVAE, SiameseNetwork
 from manify.manifolds import Manifold, ProductManifold
-from manify.predictors import KappaGCN, ProductSpaceDT, ProductSpacePerceptron, ProductSpaceRF, ProductSpaceSVM
+from manify.predictors import (
+    KappaGCN,
+    ProductSpaceDT,
+    ProductSpacePerceptron,
+    ProductSpaceRF,
+    ProductSpaceSVM,
+)
 
 # import manify.utils
 
-# Define version and other package metadata
-__version__ = "0.0.2"
+# Define version and other package metadata.
+# Read from installed package metadata so this stays in sync with pyproject.toml;
+# fall back to a literal when running from a source tree without an install.
+try:
+    __version__ = _pkg_version("manify")
+except PackageNotFoundError:  # pragma: no cover - source checkout without install
+    __version__ = "0.2.1"
 __author__ = "Philippe Chlenski"
 __email__ = "pac@cs.columbia.edu"
 __license__ = "MIT"

--- a/manify/__init__.py
+++ b/manify/__init__.py
@@ -11,20 +11,10 @@ if os.getenv("BEARTYPE_ENABLE", "false").lower() == "true":
     print("Beartype import hook installed for Manify. Will use beartype for type checking.")
 
 from manify.clustering import RiemannianFuzzyKMeans
-from manify.curvature_estimation import (
-    delta_hyperbolicity,
-    greedy_signature_selection,
-    sectional_curvature,
-)
+from manify.curvature_estimation import delta_hyperbolicity, greedy_signature_selection, sectional_curvature
 from manify.embedders import CoordinateLearning, ProductSpaceVAE, SiameseNetwork
 from manify.manifolds import Manifold, ProductManifold
-from manify.predictors import (
-    KappaGCN,
-    ProductSpaceDT,
-    ProductSpacePerceptron,
-    ProductSpaceRF,
-    ProductSpaceSVM,
-)
+from manify.predictors import KappaGCN, ProductSpaceDT, ProductSpacePerceptron, ProductSpaceRF, ProductSpaceSVM
 
 # import manify.utils
 

--- a/manify/curvature_estimation/_pipelines.py
+++ b/manify/curvature_estimation/_pipelines.py
@@ -100,7 +100,8 @@ def predictor_pipeline(
     model_init_kwargs["task"] = task
     model = classifier(pm=pm, **model_init_kwargs)
     model.fit(X=X_train, y=y_train, **model_fit_kwargs)
-    loss = model.score(X=X_test, y=y_test)
+    score = model.score(X=X_test, y=y_test)
 
-    # For classification, we want to maximize accuracy; for regression, we minimize MSE.
-    return -loss if task == "classification" else loss
+    # model.score returns accuracy (classification) or R^2 (regression); both are
+    # higher-is-better, so negate to turn them into a loss for greedy minimization.
+    return -score

--- a/manify/embedders/siamese.py
+++ b/manify/embedders/siamese.py
@@ -116,9 +116,7 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
         return self.decoder(z)
 
     def forward(
-        self,
-        x1: Float[torch.Tensor, "batch_size n_features"],
-        x2: Float[torch.Tensor, "batch_size n_features"],
+        self, x1: Float[torch.Tensor, "batch_size n_features"], x2: Float[torch.Tensor, "batch_size n_features"]
     ) -> tuple[
         Float[torch.Tensor, "batch_size n_latent"],
         Float[torch.Tensor, "batch_size n_latent"],
@@ -196,18 +194,11 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
 
         opt = torch.optim.Adam(
             [
-                {
-                    "params": [p for p in self.parameters() if p not in set(self.pm.parameters())],
-                    "lr": burn_in_lr,
-                },
+                {"params": [p for p in self.parameters() if p not in set(self.pm.parameters())], "lr": burn_in_lr},
                 {"params": self.pm.parameters(), "lr": 0},
             ]
         )
-        losses: dict[str, list[float]] = {
-            "total": [],
-            "reconstruction": [],
-            "distortion": [],
-        }
+        losses: dict[str, list[float]] = {"total": [], "reconstruction": [], "distortion": []}
 
         for epoch in range(burn_in_iterations + training_iterations):
             if epoch == burn_in_iterations:
@@ -276,11 +267,7 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
         return self
 
     def transform(
-        self,
-        X: Float[torch.Tensor, "n_points n_features"],
-        D: None = None,
-        batch_size: int = 32,
-        expmap: bool = True,
+        self, X: Float[torch.Tensor, "n_points n_features"], D: None = None, batch_size: int = 32, expmap: bool = True
     ) -> Float[torch.Tensor, "n_points n_latent"]:
         """Transforms input data into manifold embeddings.
 

--- a/manify/embedders/siamese.py
+++ b/manify/embedders/siamese.py
@@ -88,9 +88,7 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
         else:
             raise ValueError(f"Unknown reconstruction loss: {reconstruction_loss}")
 
-    def encode(
-        self, x: Float[torch.Tensor, "batch_size n_features"]
-    ) -> Float[torch.Tensor, "batch_size n_latent"]:
+    def encode(self, x: Float[torch.Tensor, "batch_size n_features"]) -> Float[torch.Tensor, "batch_size n_latent"]:
         """Encodes input data into the manifold embedding space.
 
         Takes a batch of input data and passes it through the encoder network to obtain embeddings in the manifold.
@@ -103,9 +101,7 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
         """
         return self.encoder(x)
 
-    def decode(
-        self, z: Float[torch.Tensor, "batch_size n_latent"]
-    ) -> Float[torch.Tensor, "batch_size n_features"]:
+    def decode(self, z: Float[torch.Tensor, "batch_size n_latent"]) -> Float[torch.Tensor, "batch_size n_features"]:
         """Decodes manifold embeddings back to the original input space.
 
         Takes a batch of embeddings from the manifold space and passes them through
@@ -145,9 +141,7 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
         """
         z1 = self.pm.expmap(self.encode(x1) @ self.pm.projection_matrix)
         z2 = self.pm.expmap(self.encode(x2) @ self.pm.projection_matrix)
-        D_hat = self.pm.manifold.dist(
-            z1, z2
-        )  # use manifold dist to get (batch_size, ) vector of dists
+        D_hat = self.pm.manifold.dist(z1, z2)  # use manifold dist to get (batch_size, ) vector of dists
         reconstructed1 = self.decode(z1)
         reconstructed2 = self.decode(z2)
         return z1, z2, D_hat, reconstructed1, reconstructed2
@@ -195,23 +189,15 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
 
         # Number of pairs and batches
         n_pairs = len(pairs)
-        n_batches_per_epoch = (
-            n_pairs + batch_size - 1
-        ) // batch_size  # Ceiling division
-        total_iterations = (
-            burn_in_iterations + training_iterations
-        ) * n_batches_per_epoch
+        n_batches_per_epoch = (n_pairs + batch_size - 1) // batch_size  # Ceiling division
+        total_iterations = (burn_in_iterations + training_iterations) * n_batches_per_epoch
 
         my_tqdm = tqdm(total=total_iterations)
 
         opt = torch.optim.Adam(
             [
                 {
-                    "params": [
-                        p
-                        for p in self.parameters()
-                        if p not in set(self.pm.parameters())
-                    ],
+                    "params": [p for p in self.parameters() if p not in set(self.pm.parameters())],
                     "lr": burn_in_lr,
                 },
                 {"params": self.pm.parameters(), "lr": 0},
@@ -277,17 +263,10 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
 
                 # Logging
                 if my_tqdm.n % logging_interval == 0:
-                    d = {
-                        f"r{i}": f"{logscale.item():.3f}"
-                        for i, logscale in enumerate(self.pm.parameters())
-                    }
+                    d = {f"r{i}": f"{logscale.item():.3f}" for i, logscale in enumerate(self.pm.parameters())}
                     d["L_avg"] = f"{np.mean(losses['total'][-loss_window_size:]):.3e}"
-                    d["recon_avg"] = (
-                        f"{np.mean(losses['reconstruction'][-loss_window_size:]):.3e}"
-                    )
-                    d["dist_avg"] = (
-                        f"{np.mean(losses['distortion'][-loss_window_size:]):.3e}"
-                    )
+                    d["recon_avg"] = f"{np.mean(losses['reconstruction'][-loss_window_size:]):.3e}"
+                    d["dist_avg"] = f"{np.mean(losses['distortion'][-loss_window_size:]):.3e}"
                     my_tqdm.set_postfix(d)
 
         # Final maintenance: update attributes

--- a/manify/embedders/siamese.py
+++ b/manify/embedders/siamese.py
@@ -88,7 +88,9 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
         else:
             raise ValueError(f"Unknown reconstruction loss: {reconstruction_loss}")
 
-    def encode(self, x: Float[torch.Tensor, "batch_size n_features"]) -> Float[torch.Tensor, "batch_size n_latent"]:
+    def encode(
+        self, x: Float[torch.Tensor, "batch_size n_features"]
+    ) -> Float[torch.Tensor, "batch_size n_latent"]:
         """Encodes input data into the manifold embedding space.
 
         Takes a batch of input data and passes it through the encoder network to obtain embeddings in the manifold.
@@ -101,7 +103,9 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
         """
         return self.encoder(x)
 
-    def decode(self, z: Float[torch.Tensor, "batch_size n_latent"]) -> Float[torch.Tensor, "batch_size n_features"]:
+    def decode(
+        self, z: Float[torch.Tensor, "batch_size n_latent"]
+    ) -> Float[torch.Tensor, "batch_size n_features"]:
         """Decodes manifold embeddings back to the original input space.
 
         Takes a batch of embeddings from the manifold space and passes them through
@@ -116,8 +120,10 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
         return self.decoder(z)
 
     def forward(
-        self, x1: Float[torch.Tensor, "batch_size n_features"], x2: Float[torch.Tensor, "batch_size n_features"]
-    ) -> Tuple[
+        self,
+        x1: Float[torch.Tensor, "batch_size n_features"],
+        x2: Float[torch.Tensor, "batch_size n_features"],
+    ) -> tuple[
         Float[torch.Tensor, "batch_size n_latent"],
         Float[torch.Tensor, "batch_size n_latent"],
         Float[torch.Tensor, "batch_size"],
@@ -139,7 +145,9 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
         """
         z1 = self.pm.expmap(self.encode(x1) @ self.pm.projection_matrix)
         z2 = self.pm.expmap(self.encode(x2) @ self.pm.projection_matrix)
-        D_hat = self.pm.manifold.dist(z1, z2)  # use manifold dist to get (batch_size, ) vector of dists
+        D_hat = self.pm.manifold.dist(
+            z1, z2
+        )  # use manifold dist to get (batch_size, ) vector of dists
         reconstructed1 = self.decode(z1)
         reconstructed2 = self.decode(z2)
         return z1, z2, D_hat, reconstructed1, reconstructed2
@@ -187,18 +195,33 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
 
         # Number of pairs and batches
         n_pairs = len(pairs)
-        n_batches_per_epoch = (n_pairs + batch_size - 1) // batch_size  # Ceiling division
-        total_iterations = (burn_in_iterations + training_iterations) * n_batches_per_epoch
+        n_batches_per_epoch = (
+            n_pairs + batch_size - 1
+        ) // batch_size  # Ceiling division
+        total_iterations = (
+            burn_in_iterations + training_iterations
+        ) * n_batches_per_epoch
 
         my_tqdm = tqdm(total=total_iterations)
 
         opt = torch.optim.Adam(
             [
-                {"params": [p for p in self.parameters() if p not in set(self.pm.parameters())], "lr": burn_in_lr},
+                {
+                    "params": [
+                        p
+                        for p in self.parameters()
+                        if p not in set(self.pm.parameters())
+                    ],
+                    "lr": burn_in_lr,
+                },
                 {"params": self.pm.parameters(), "lr": 0},
             ]
         )
-        losses: Dict[str, List[float]] = {"total": [], "reconstruction": [], "distortion": []}
+        losses: dict[str, list[float]] = {
+            "total": [],
+            "reconstruction": [],
+            "distortion": [],
+        }
 
         for epoch in range(burn_in_iterations + training_iterations):
             if epoch == burn_in_iterations:
@@ -254,10 +277,17 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
 
                 # Logging
                 if my_tqdm.n % logging_interval == 0:
-                    d = {f"r{i}": f"{logscale.item():.3f}" for i, logscale in enumerate(self.pm.parameters())}
+                    d = {
+                        f"r{i}": f"{logscale.item():.3f}"
+                        for i, logscale in enumerate(self.pm.parameters())
+                    }
                     d["L_avg"] = f"{np.mean(losses['total'][-loss_window_size:]):.3e}"
-                    d["recon_avg"] = f"{np.mean(losses['reconstruction'][-loss_window_size:]):.3e}"
-                    d["dist_avg"] = f"{np.mean(losses['distortion'][-loss_window_size:]):.3e}"
+                    d["recon_avg"] = (
+                        f"{np.mean(losses['reconstruction'][-loss_window_size:]):.3e}"
+                    )
+                    d["dist_avg"] = (
+                        f"{np.mean(losses['distortion'][-loss_window_size:]):.3e}"
+                    )
                     my_tqdm.set_postfix(d)
 
         # Final maintenance: update attributes
@@ -267,7 +297,11 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
         return self
 
     def transform(
-        self, X: Float[torch.Tensor, "n_points n_features"], D: None = None, batch_size: int = 32, expmap: bool = True
+        self,
+        X: Float[torch.Tensor, "n_points n_features"],
+        D: None = None,
+        batch_size: int = 32,
+        expmap: bool = True,
     ) -> Float[torch.Tensor, "n_points n_latent"]:
         """Transforms input data into manifold embeddings.
 

--- a/manify/embedders/vae.py
+++ b/manify/embedders/vae.py
@@ -92,25 +92,21 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         self.beta = beta
         self.n_samples = n_samples
         self.reconstruction_loss = (
-            reconstruction_loss
-            if reconstruction_loss is not None
-            else torch.nn.MSELoss(reduction="none")
+            reconstruction_loss if reconstruction_loss is not None else torch.nn.MSELoss(reduction="none")
         )
         self.model_ = None
         self.loss_history_ = {}
         self.is_fitted_ = False
 
         # Ensure encoder last dimension is 2 * pm.intrinsic_dim:
-        assert (
-            encoder[-1].out_features == 2 * pm.dim
-        ), "Encoder output must match 2 * intrinsic dimension of manifold."
+        assert encoder[-1].out_features == 2 * pm.dim, "Encoder output must match 2 * intrinsic dimension of manifold."
 
         # Ensure decoder input dimension is pm.intrinsic_dim
-        assert (
-            decoder[0].in_features == pm.ambient_dim
-        ), "Decoder input must match ambient dimension of manifold."
+        assert decoder[0].in_features == pm.ambient_dim, "Decoder input must match ambient dimension of manifold."
 
-    def encode(self, x: Float[torch.Tensor, "batch_size n_features"]) -> tuple[
+    def encode(
+        self, x: Float[torch.Tensor, "batch_size n_features"]
+    ) -> tuple[
         Float[torch.Tensor, "batch_size n_latent"],
         Float[torch.Tensor, "batch_size n_latent"],
     ]:
@@ -136,9 +132,7 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         # z_mean = self.pm.expmap(u=z_mean_ambient, base=None)
         return z_mean_tangent, z_logvar
 
-    def decode(
-        self, z: Float[torch.Tensor, "batch_size n_ambient"]
-    ) -> Float[torch.Tensor, "batch_size n_features"]:
+    def decode(self, z: Float[torch.Tensor, "batch_size n_ambient"]) -> Float[torch.Tensor, "batch_size n_features"]:
         """Decodes latent points from the manifold space back to the input space.
 
         Takes points from the product manifold latent space and passes them through
@@ -153,7 +147,9 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         """
         return self.decoder(z)
 
-    def forward(self, x: Float[torch.Tensor, "batch_size n_features"]) -> tuple[
+    def forward(
+        self, x: Float[torch.Tensor, "batch_size n_features"]
+    ) -> tuple[
         Float[torch.Tensor, "batch_size n_features"],
         Float[torch.Tensor, "batch_size n_ambient"],
         list[Float[torch.Tensor, "batch_size n_latent n_latent"]],
@@ -179,17 +175,12 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         z_mean_tangent, z_logvars = self.encode(x)
 
         # Need to convert from implicit parameterization to extrinsic coordinates
-        z_mean_ambient = (
-            z_mean_tangent @ self.pm.projection_matrix
-        )  # Adds zeros in the right places
+        z_mean_ambient = z_mean_tangent @ self.pm.projection_matrix  # Adds zeros in the right places
         z_means = self.pm.expmap(u=z_mean_ambient, base=None)
 
         # Factorize log-variances; convert to covariances
         sigma_factorized = self.pm.factorize(z_logvars, intrinsic=True)
-        sigmas = [
-            torch.diag_embed(torch.exp(z_logvar) + 1e-8)
-            for z_logvar in sigma_factorized
-        ]
+        sigmas = [torch.diag_embed(torch.exp(z_logvar) + 1e-8) for z_logvar in sigma_factorized]
 
         # Sample and decode
         z = self.pm.sample(z_mean=z_means, sigma_factorized=sigmas)
@@ -199,9 +190,7 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
     def kl_divergence(
         self,
         z_mean: Float[torch.Tensor, "batch_size n_latent"],
-        sigma_factorized: list[
-            Float[torch.Tensor, "batch_size manifold_dim manifold_dim"]
-        ],
+        sigma_factorized: list[Float[torch.Tensor, "batch_size manifold_dim manifold_dim"]],
     ) -> Float[torch.Tensor, "batch_size"]:
         r"""Computes the KL divergence between posterior and prior distributions in the manifold.
 
@@ -225,22 +214,17 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         # Get KL divergence as the average of log q(z|x) - log p(z)
         means = torch.repeat_interleave(z_mean, self.n_samples, dim=0)
         sigmas_factorized_interleaved = [
-            torch.repeat_interleave(sigma, self.n_samples, dim=0)
-            for sigma in sigma_factorized
+            torch.repeat_interleave(sigma, self.n_samples, dim=0) for sigma in sigma_factorized
         ]
         # We want to use n_samples = 1 here, since we'll need to pass the interleaved means/sigmas to the log-likelihood
-        z_samples = self.pm.sample(
-            z_mean=means, sigma_factorized=sigmas_factorized_interleaved
-        )
+        z_samples = self.pm.sample(z_mean=means, sigma_factorized=sigmas_factorized_interleaved)
         log_qz = self.pm.log_likelihood(z_samples, means, sigmas_factorized_interleaved)
         log_pz = self.pm.log_likelihood(z_samples)
         return (log_qz - log_pz).view(-1, self.n_samples).mean(dim=1)
 
     def elbo(
         self, x: Float[torch.Tensor, "batch_size n_features"]
-    ) -> tuple[
-        Float[torch.Tensor, ""], Float[torch.Tensor, ""], Float[torch.Tensor, ""]
-    ]:
+    ) -> tuple[Float[torch.Tensor, ""], Float[torch.Tensor, ""], Float[torch.Tensor, ""]]:
         r"""Computes the Evidence Lower Bound (ELBO) for the VAE objective.
 
         The ELBO is the standard objective function for variational autoencoders, consisting of a reconstruction term
@@ -264,9 +248,7 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         """
         x_reconstructed, z_means, sigma_factorized = self(x)
         kld = self.kl_divergence(z_means, sigma_factorized)
-        ll = -self.reconstruction_loss(
-            x_reconstructed.view(x.shape[0], -1), x.view(x.shape[0], -1)
-        ).sum(dim=1)
+        ll = -self.reconstruction_loss(x_reconstructed.view(x.shape[0], -1), x.view(x.shape[0], -1)).sum(dim=1)
         return (ll - self.beta * kld).mean(), ll.mean(), kld.mean()
 
     def _grads_ok(self) -> bool:
@@ -336,11 +318,7 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         opt = torch.optim.Adam(
             [
                 {
-                    "params": [
-                        p
-                        for p in self.parameters()
-                        if p not in set(self.pm.parameters())
-                    ],
+                    "params": [p for p in self.parameters() if p not in set(self.pm.parameters())],
                     "lr": burn_in_lr,
                 },
                 {"params": self.pm.parameters(), "lr": 0},
@@ -375,16 +353,11 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
 
                 # TQDM management
                 my_tqdm.update(batch_size)
-                my_tqdm.set_description(
-                    f"L: {L.item():.3e}, ll: {ll.item():.3e}, kl: {kl.item():.3e}"
-                )
+                my_tqdm.set_description(f"L: {L.item():.3e}, ll: {ll.item():.3e}, kl: {kl.item():.3e}")
 
                 # Logging
                 if i % logging_interval == 0:
-                    d = {
-                        f"r{i}": f"{logscale.item():.3f}"
-                        for i, logscale in enumerate(self.pm.parameters())
-                    }
+                    d = {f"r{i}": f"{logscale.item():.3f}" for i, logscale in enumerate(self.pm.parameters())}
                     # d["D_avg"] = f"{d_avg(D_tt, D[train][:, train], pairwise=True):.4f}"
                     d["L_avg"] = f"{np.mean(losses['elbo'][-loss_window_size:]):.3e}"
                     d["ll_avg"] = f"{np.mean(losses['ll'][-loss_window_size:]):.3e}"
@@ -425,9 +398,7 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
             x_batch = X[i : i + batch_size]
             z_mean_tangent, _ = self.encode(x_batch)
             if expmap:
-                z_mean_ambient = (
-                    z_mean_tangent @ self.pm.projection_matrix
-                )  # Adds zeros in the right places
+                z_mean_ambient = z_mean_tangent @ self.pm.projection_matrix  # Adds zeros in the right places
                 z_mean = self.pm.expmap(u=z_mean_ambient, base=None)
             else:
                 z_mean = z_mean_tangent

--- a/manify/embedders/vae.py
+++ b/manify/embedders/vae.py
@@ -92,21 +92,28 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         self.beta = beta
         self.n_samples = n_samples
         self.reconstruction_loss = (
-            reconstruction_loss if reconstruction_loss is not None else torch.nn.MSELoss(reduction="none")
+            reconstruction_loss
+            if reconstruction_loss is not None
+            else torch.nn.MSELoss(reduction="none")
         )
         self.model_ = None
         self.loss_history_ = {}
         self.is_fitted_ = False
 
         # Ensure encoder last dimension is 2 * pm.intrinsic_dim:
-        assert encoder[-1].out_features == 2 * pm.dim, "Encoder output must match 2 * intrinsic dimension of manifold."
+        assert (
+            encoder[-1].out_features == 2 * pm.dim
+        ), "Encoder output must match 2 * intrinsic dimension of manifold."
 
         # Ensure decoder input dimension is pm.intrinsic_dim
-        assert decoder[0].in_features == pm.ambient_dim, "Decoder input must match ambient dimension of manifold."
+        assert (
+            decoder[0].in_features == pm.ambient_dim
+        ), "Decoder input must match ambient dimension of manifold."
 
-    def encode(
-        self, x: Float[torch.Tensor, "batch_size n_features"]
-    ) -> tuple[Float[torch.Tensor, "batch_size n_latent"], Float[torch.Tensor, "batch_size n_latent"]]:
+    def encode(self, x: Float[torch.Tensor, "batch_size n_features"]) -> tuple[
+        Float[torch.Tensor, "batch_size n_latent"],
+        Float[torch.Tensor, "batch_size n_latent"],
+    ]:
         r"""Encodes input data to obtain latent means and log-variances in the manifold.
 
         This method processes input data through the encoder network to obtain parameters of the approximate posterior
@@ -129,7 +136,9 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         # z_mean = self.pm.expmap(u=z_mean_ambient, base=None)
         return z_mean_tangent, z_logvar
 
-    def decode(self, z: Float[torch.Tensor, "batch_size n_ambient"]) -> Float[torch.Tensor, "batch_size n_features"]:
+    def decode(
+        self, z: Float[torch.Tensor, "batch_size n_ambient"]
+    ) -> Float[torch.Tensor, "batch_size n_features"]:
         """Decodes latent points from the manifold space back to the input space.
 
         Takes points from the product manifold latent space and passes them through
@@ -144,9 +153,7 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         """
         return self.decoder(z)
 
-    def forward(
-        self, x: Float[torch.Tensor, "batch_size n_features"]
-    ) -> tuple[
+    def forward(self, x: Float[torch.Tensor, "batch_size n_features"]) -> tuple[
         Float[torch.Tensor, "batch_size n_features"],
         Float[torch.Tensor, "batch_size n_ambient"],
         list[Float[torch.Tensor, "batch_size n_latent n_latent"]],
@@ -172,12 +179,17 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         z_mean_tangent, z_logvars = self.encode(x)
 
         # Need to convert from implicit parameterization to extrinsic coordinates
-        z_mean_ambient = z_mean_tangent @ self.pm.projection_matrix  # Adds zeros in the right places
+        z_mean_ambient = (
+            z_mean_tangent @ self.pm.projection_matrix
+        )  # Adds zeros in the right places
         z_means = self.pm.expmap(u=z_mean_ambient, base=None)
 
         # Factorize log-variances; convert to covariances
         sigma_factorized = self.pm.factorize(z_logvars, intrinsic=True)
-        sigmas = [torch.diag_embed(torch.exp(z_logvar) + 1e-8) for z_logvar in sigma_factorized]
+        sigmas = [
+            torch.diag_embed(torch.exp(z_logvar) + 1e-8)
+            for z_logvar in sigma_factorized
+        ]
 
         # Sample and decode
         z = self.pm.sample(z_mean=z_means, sigma_factorized=sigmas)
@@ -187,7 +199,9 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
     def kl_divergence(
         self,
         z_mean: Float[torch.Tensor, "batch_size n_latent"],
-        sigma_factorized: list[Float[torch.Tensor, "batch_size manifold_dim manifold_dim"]],
+        sigma_factorized: list[
+            Float[torch.Tensor, "batch_size manifold_dim manifold_dim"]
+        ],
     ) -> Float[torch.Tensor, "batch_size"]:
         r"""Computes the KL divergence between posterior and prior distributions in the manifold.
 
@@ -211,17 +225,22 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         # Get KL divergence as the average of log q(z|x) - log p(z)
         means = torch.repeat_interleave(z_mean, self.n_samples, dim=0)
         sigmas_factorized_interleaved = [
-            torch.repeat_interleave(sigma, self.n_samples, dim=0) for sigma in sigma_factorized
+            torch.repeat_interleave(sigma, self.n_samples, dim=0)
+            for sigma in sigma_factorized
         ]
         # We want to use n_samples = 1 here, since we'll need to pass the interleaved means/sigmas to the log-likelihood
-        z_samples = self.pm.sample(z_mean=means, sigma_factorized=sigmas_factorized_interleaved)
+        z_samples = self.pm.sample(
+            z_mean=means, sigma_factorized=sigmas_factorized_interleaved
+        )
         log_qz = self.pm.log_likelihood(z_samples, means, sigmas_factorized_interleaved)
         log_pz = self.pm.log_likelihood(z_samples)
         return (log_qz - log_pz).view(-1, self.n_samples).mean(dim=1)
 
     def elbo(
         self, x: Float[torch.Tensor, "batch_size n_features"]
-    ) -> tuple[Float[torch.Tensor, ""], Float[torch.Tensor, ""], Float[torch.Tensor, ""]]:
+    ) -> tuple[
+        Float[torch.Tensor, ""], Float[torch.Tensor, ""], Float[torch.Tensor, ""]
+    ]:
         r"""Computes the Evidence Lower Bound (ELBO) for the VAE objective.
 
         The ELBO is the standard objective function for variational autoencoders, consisting of a reconstruction term
@@ -245,7 +264,9 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         """
         x_reconstructed, z_means, sigma_factorized = self(x)
         kld = self.kl_divergence(z_means, sigma_factorized)
-        ll = -self.reconstruction_loss(x_reconstructed.view(x.shape[0], -1), x.view(x.shape[0], -1)).sum(dim=1)
+        ll = -self.reconstruction_loss(
+            x_reconstructed.view(x.shape[0], -1), x.view(x.shape[0], -1)
+        ).sum(dim=1)
         return (ll - self.beta * kld).mean(), ll.mean(), kld.mean()
 
     def _grads_ok(self) -> bool:
@@ -314,11 +335,18 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         my_tqdm = tqdm(total=(burn_in_iterations + training_iterations) * len(X))
         opt = torch.optim.Adam(
             [
-                {"params": [p for p in self.parameters() if p not in set(self.pm.parameters())], "lr": burn_in_lr},
+                {
+                    "params": [
+                        p
+                        for p in self.parameters()
+                        if p not in set(self.pm.parameters())
+                    ],
+                    "lr": burn_in_lr,
+                },
                 {"params": self.pm.parameters(), "lr": 0},
             ]
         )
-        losses: Dict[str, List[float]] = {"elbo": [], "ll": [], "kl": []}
+        losses: dict[str, list[float]] = {"elbo": [], "ll": [], "kl": []}
         for epoch in range(burn_in_iterations + training_iterations):
             if epoch == burn_in_iterations:
                 opt.param_groups[0]["lr"] = lr
@@ -347,11 +375,16 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
 
                 # TQDM management
                 my_tqdm.update(batch_size)
-                my_tqdm.set_description(f"L: {L.item():.3e}, ll: {ll.item():.3e}, kl: {kl.item():.3e}")
+                my_tqdm.set_description(
+                    f"L: {L.item():.3e}, ll: {ll.item():.3e}, kl: {kl.item():.3e}"
+                )
 
                 # Logging
                 if i % logging_interval == 0:
-                    d = {f"r{i}": f"{logscale.item():.3f}" for i, logscale in enumerate(self.pm.parameters())}
+                    d = {
+                        f"r{i}": f"{logscale.item():.3f}"
+                        for i, logscale in enumerate(self.pm.parameters())
+                    }
                     # d["D_avg"] = f"{d_avg(D_tt, D[train][:, train], pairwise=True):.4f}"
                     d["L_avg"] = f"{np.mean(losses['elbo'][-loss_window_size:]):.3e}"
                     d["ll_avg"] = f"{np.mean(losses['ll'][-loss_window_size:]):.3e}"
@@ -365,7 +398,11 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         return self
 
     def transform(
-        self, X: Float[torch.Tensor, "n_points n_features"], D: None = None, batch_size: int = 32, expmap: bool = True
+        self,
+        X: Float[torch.Tensor, "n_points n_features"],
+        D: None = None,
+        batch_size: int = 32,
+        expmap: bool = True,
     ) -> Float[torch.Tensor, "n_points embedding_dim"]:
         """Transform data using the trained VAE. Outputs means of the variational distribution.
 
@@ -388,7 +425,9 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
             x_batch = X[i : i + batch_size]
             z_mean_tangent, _ = self.encode(x_batch)
             if expmap:
-                z_mean_ambient = z_mean_tangent @ self.pm.projection_matrix  # Adds zeros in the right places
+                z_mean_ambient = (
+                    z_mean_tangent @ self.pm.projection_matrix
+                )  # Adds zeros in the right places
                 z_mean = self.pm.expmap(u=z_mean_ambient, base=None)
             else:
                 z_mean = z_mean_tangent

--- a/manify/embedders/vae.py
+++ b/manify/embedders/vae.py
@@ -106,10 +106,7 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
 
     def encode(
         self, x: Float[torch.Tensor, "batch_size n_features"]
-    ) -> tuple[
-        Float[torch.Tensor, "batch_size n_latent"],
-        Float[torch.Tensor, "batch_size n_latent"],
-    ]:
+    ) -> tuple[Float[torch.Tensor, "batch_size n_latent"], Float[torch.Tensor, "batch_size n_latent"]]:
         r"""Encodes input data to obtain latent means and log-variances in the manifold.
 
         This method processes input data through the encoder network to obtain parameters of the approximate posterior
@@ -317,10 +314,7 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         my_tqdm = tqdm(total=(burn_in_iterations + training_iterations) * len(X))
         opt = torch.optim.Adam(
             [
-                {
-                    "params": [p for p in self.parameters() if p not in set(self.pm.parameters())],
-                    "lr": burn_in_lr,
-                },
+                {"params": [p for p in self.parameters() if p not in set(self.pm.parameters())], "lr": burn_in_lr},
                 {"params": self.pm.parameters(), "lr": 0},
             ]
         )
@@ -371,11 +365,7 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         return self
 
     def transform(
-        self,
-        X: Float[torch.Tensor, "n_points n_features"],
-        D: None = None,
-        batch_size: int = 32,
-        expmap: bool = True,
+        self, X: Float[torch.Tensor, "n_points n_features"], D: None = None, batch_size: int = 32, expmap: bool = True
     ) -> Float[torch.Tensor, "n_points embedding_dim"]:
         """Transform data using the trained VAE. Outputs means of the variational distribution.
 

--- a/manify/predictors/_base.py
+++ b/manify/predictors/_base.py
@@ -63,8 +63,7 @@ class BasePredictor(BaseEstimator, ABC):
             raise ValueError(f"Unknown task type: {task}")
 
     def _store_classes(
-        self,
-        y: Float[torch.Tensor, "n_points n_classes"] | Float[torch.Tensor, "n_points"],
+        self, y: Float[torch.Tensor, "n_points n_classes"] | Float[torch.Tensor, "n_points"]
     ) -> Float[torch.Tensor, "n_points"]:
         """Store unique classes and return relabeled y for classification tasks."""
         if self.task == "classification":
@@ -149,6 +148,7 @@ class BasePredictor(BaseEstimator, ABC):
 
         if sample_weight is None:
             sample_weight = torch.ones_like(predictions, dtype=torch.float32)
+
         total_weight = sample_weight.sum()
 
         if self.task in ("classification", "link_prediction"):

--- a/manify/predictors/_base.py
+++ b/manify/predictors/_base.py
@@ -97,9 +97,7 @@ class BasePredictor(BaseEstimator, ABC):
         pass
 
     @abstractmethod
-    def predict_proba(
-        self, X: Float[torch.Tensor, "n_points n_features"]
-    ) -> Float[torch.Tensor, "n_points n_classes"]:
+    def predict_proba(self, X: Float[torch.Tensor, "n_points n_features"]) -> Float[torch.Tensor, "n_points n_classes"]:
         """Compute the predicted probabilities for the given features.
 
         Args:
@@ -110,9 +108,7 @@ class BasePredictor(BaseEstimator, ABC):
         """
         pass
 
-    def predict(
-        self, X: Float[torch.Tensor, "n_points n_features"], **kwargs: Any
-    ) -> Float[torch.Tensor, "n_points"]:
+    def predict(self, X: Float[torch.Tensor, "n_points n_features"], **kwargs: Any) -> Float[torch.Tensor, "n_points"]:
         """Compute the predicted classes for the given features.
 
         Args:
@@ -157,9 +153,7 @@ class BasePredictor(BaseEstimator, ABC):
 
         if self.task in ("classification", "link_prediction"):
             # Weighted accuracy (matches sklearn's accuracy_score with sample_weight)
-            out = (
-                (predictions == y).float() * sample_weight
-            ).sum().item() / total_weight.item()
+            out = ((predictions == y).float() * sample_weight).sum().item() / total_weight.item()
         else:  # regression
             # Weighted R^2 (matches sklearn's RegressorMixin.score: higher is better)
             y_mean = (y * sample_weight).sum() / total_weight

--- a/manify/predictors/_base.py
+++ b/manify/predictors/_base.py
@@ -9,7 +9,7 @@ import torch
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 
 if TYPE_CHECKING:
-    from beartype.typing import Literal
+    from beartype.typing import Any, Literal
     from jaxtyping import Float
 
 from ..manifolds import ProductManifold
@@ -111,7 +111,7 @@ class BasePredictor(BaseEstimator, ABC):
         pass
 
     def predict(
-        self, X: Float[torch.Tensor, "n_points n_features"], **kwargs: dict
+        self, X: Float[torch.Tensor, "n_points n_features"], **kwargs: Any
     ) -> Float[torch.Tensor, "n_points"]:
         """Compute the predicted classes for the given features.
 
@@ -136,7 +136,7 @@ class BasePredictor(BaseEstimator, ABC):
         X: Float[torch.Tensor, "n_points n_features"],
         y: Float[torch.Tensor, "n_points n_classes"] | Float[torch.Tensor, "n_points"],
         sample_weight: Float[torch.Tensor, "n_points"] | None = None,
-        **kwargs: dict,
+        **kwargs: Any,
     ) -> float:
         """Return the mean accuracy/R² score.
 

--- a/manify/predictors/_base.py
+++ b/manify/predictors/_base.py
@@ -63,7 +63,8 @@ class BasePredictor(BaseEstimator, ABC):
             raise ValueError(f"Unknown task type: {task}")
 
     def _store_classes(
-        self, y: Float[torch.Tensor, "n_points n_classes"] | Float[torch.Tensor, "n_points"]
+        self,
+        y: Float[torch.Tensor, "n_points n_classes"] | Float[torch.Tensor, "n_points"],
     ) -> Float[torch.Tensor, "n_points"]:
         """Store unique classes and return relabeled y for classification tasks."""
         if self.task == "classification":
@@ -96,7 +97,9 @@ class BasePredictor(BaseEstimator, ABC):
         pass
 
     @abstractmethod
-    def predict_proba(self, X: Float[torch.Tensor, "n_points n_features"]) -> Float[torch.Tensor, "n_points n_classes"]:
+    def predict_proba(
+        self, X: Float[torch.Tensor, "n_points n_features"]
+    ) -> Float[torch.Tensor, "n_points n_classes"]:
         """Compute the predicted probabilities for the given features.
 
         Args:
@@ -107,7 +110,9 @@ class BasePredictor(BaseEstimator, ABC):
         """
         pass
 
-    def predict(self, X: Float[torch.Tensor, "n_points n_features"], **kwargs: dict) -> Float[torch.Tensor, "n_points"]:
+    def predict(
+        self, X: Float[torch.Tensor, "n_points n_features"], **kwargs: dict
+    ) -> Float[torch.Tensor, "n_points"]:
         """Compute the predicted classes for the given features.
 
         Args:
@@ -148,12 +153,18 @@ class BasePredictor(BaseEstimator, ABC):
 
         if sample_weight is None:
             sample_weight = torch.ones_like(predictions, dtype=torch.float32)
+        total_weight = sample_weight.sum()
 
-        if self.task == "classification":
-            out = ((predictions == y).float() * sample_weight).mean().item()
-        elif self.task == "regression":
-            out = (((predictions - y) ** 2 * sample_weight).mean()).item()
-        else:  # link_prediction
-            out = ((predictions == y).float() * sample_weight).mean().item()
+        if self.task in ("classification", "link_prediction"):
+            # Weighted accuracy (matches sklearn's accuracy_score with sample_weight)
+            out = (
+                (predictions == y).float() * sample_weight
+            ).sum().item() / total_weight.item()
+        else:  # regression
+            # Weighted R^2 (matches sklearn's RegressorMixin.score: higher is better)
+            y_mean = (y * sample_weight).sum() / total_weight
+            ss_res = (sample_weight * (y - predictions) ** 2).sum()
+            ss_tot = (sample_weight * (y - y_mean) ** 2).sum()
+            out = (1.0 - ss_res / ss_tot).item() if ss_tot > 0 else 0.0
 
         return float(out)

--- a/manify/predictors/decision_tree.py
+++ b/manify/predictors/decision_tree.py
@@ -37,10 +37,7 @@ def _angular_greater(
 
 def _get_info_gains(
     comparisons: Float[torch.Tensor, "query_batch dims key_batch"],
-    labels: (
-        Float[torch.Tensor, "query_batch n_classes"]
-        | Float[torch.Tensor, "query_batch"]
-    ),
+    labels: (Float[torch.Tensor, "query_batch n_classes"] | Float[torch.Tensor, "query_batch"]),
     criterion: Literal["gini", "mse"] = "gini",
     min_values_leaf: int = 1,
     eps: float = 1e-10,
@@ -137,21 +134,15 @@ def _get_info_gains_nobatch(
     """
     # Matrix-multiply to get counts of labels in left and right splits
     if criterion == "gini":
-        pos_labels = torch.zeros(
-            (angles.shape[0], angles.shape[1], labels.shape[1]), device=angles.device
-        )
-        neg_labels = torch.zeros(
-            (angles.shape[0], angles.shape[1], labels.shape[1]), device=angles.device
-        )
+        pos_labels = torch.zeros((angles.shape[0], angles.shape[1], labels.shape[1]), device=angles.device)
+        neg_labels = torch.zeros((angles.shape[0], angles.shape[1], labels.shape[1]), device=angles.device)
 
         for d in range(angles.shape[1]):
             for j in range(0, angles.shape[0]):
                 mask = _angular_greater(angles[:, d], angles[j, d])
 
                 # Expanding the labels to match the broadcasting needs of the mask
-                pos_labels_entry = (
-                    mask.float() * labels
-                )  # [batch_size, labels.shape[1]]
+                pos_labels_entry = mask.float() * labels  # [batch_size, labels.shape[1]]
                 neg_labels_entry = ~mask * labels  # [batch_size, labels.shape[1]]
 
                 # Assign the calculated values to the respective positions in the final tensors
@@ -195,22 +186,17 @@ def _get_split(
     mask: Bool[torch.Tensor, "query_batch"],
     angles: Float[torch.Tensor, "query_batch dims"],
     comparisons: Float[torch.Tensor, "query_batch dims key_batch"],
-    labels: (
-        Float[torch.Tensor, "query_batch n_classes"]
-        | Float[torch.Tensor, "query_batch"]
-    ),
+    labels: (Float[torch.Tensor, "query_batch n_classes"] | Float[torch.Tensor, "query_batch"]),
 ) -> tuple[
     tuple[
         Float[torch.Tensor, "query_batch_neg dims"],
         Float[torch.Tensor, "query_batch_neg dims query_batch_neg"],
-        Float[torch.Tensor, "query_batch_neg n_classes"]
-        | Float[torch.Tensor, "query_batch_neg"],
+        Float[torch.Tensor, "query_batch_neg n_classes"] | Float[torch.Tensor, "query_batch_neg"],
     ],
     tuple[
         Float[torch.Tensor, "query_batch_pos dims"],
         Float[torch.Tensor, "query_batch_pos dims query_batch_pos"],
-        Float[torch.Tensor, "query_batch_pos n_classes"]
-        | Float[torch.Tensor, "query_batch_pos"],
+        Float[torch.Tensor, "query_batch_pos n_classes"] | Float[torch.Tensor, "query_batch_pos"],
     ],
 ]:
     """Split tensors into negative and positive classes based on the mask.
@@ -286,9 +272,7 @@ class ProductSpaceDT(BasePredictor):
         min_samples_leaf: int = 1,
         min_samples_split: int = 2,
         min_impurity_decrease: float = 0.0,
-        task: Literal[
-            "classification", "regression", "link_prediction"
-        ] = "classification",
+        task: Literal["classification", "regression", "link_prediction"] = "classification",
         use_special_dims: bool = False,
         batch_size: int | None = None,
         n_features: Literal["d", "d_choose_2"] = "d",
@@ -301,9 +285,7 @@ class ProductSpaceDT(BasePredictor):
 
         # Raise error if manifold is stereographic
         if pm.is_stereographic:
-            raise ValueError(
-                "Stereographic manifolds are not supported. Use a different representation."
-            )
+            raise ValueError("Stereographic manifolds are not supported. Use a different representation.")
         if task == "link_prediction":
             raise ValueError(
                 "Link prediction is not supported for decision trees. Please use utils.link_prediction to reframe as classification"
@@ -332,26 +314,14 @@ class ProductSpaceDT(BasePredictor):
 
         # These will become important later, when fit is called
         self.nodes: list[_DecisionNode] = []  # For fitted nodes
-        self.permutations: Int[torch.Tensor, "n_classes"] | None = (
-            None  # If used as part of a random forest
-        )
+        self.permutations: Int[torch.Tensor, "n_classes"] | None = None  # If used as part of a random forest
         self.angle2man: list[int] = []  # Maps preprocessed angles to manifold indices
-        self.special_first: list[bool] = (
-            []
-        )  # Whether the first dimension is special in a projection
-        self.angle_dims: list[tuple[int, int]] = (
-            []
-        )  # Maps preprocessed angles to dimension indices
+        self.special_first: list[bool] = []  # Whether the first dimension is special in a projection
+        self.angle_dims: list[tuple[int, int]] = []  # Maps preprocessed angles to dimension indices
         self.tree: _DecisionNode = _DecisionNode()  # The root of the tree
-        self.classes_: Float[torch.Tensor, "n_classes"] = torch.empty(
-            0
-        )  # Initialize as an empty tensor
-        self.labels_: Int[torch.Tensor, "batch n_classes"] = torch.tensor(
-            []
-        )  # sklearn-style labels
-        self.signature: list[tuple[float, int]] = (
-            pm.signature
-        )  # The signature of the manifold
+        self.classes_: Float[torch.Tensor, "n_classes"] = torch.empty(0)  # Initialize as an empty tensor
+        self.labels_: Int[torch.Tensor, "batch n_classes"] = torch.tensor([])  # sklearn-style labels
+        self.signature: list[tuple[float, int]] = pm.signature  # The signature of the manifold
 
     def _preprocess(
         self,
@@ -359,9 +329,7 @@ class ProductSpaceDT(BasePredictor):
         y: Real[torch.Tensor, "batch"] | None = None,
     ) -> tuple[
         Float[torch.Tensor, "batch intrinsic_dim"],  # angles
-        Float[torch.Tensor, "batch n_classes"]
-        | Float[torch.Tensor, "batch"]
-        | Float[torch.Tensor, "0"],  # labels
+        Float[torch.Tensor, "batch n_classes"] | Float[torch.Tensor, "batch"] | Float[torch.Tensor, "0"],  # labels
         Float[torch.Tensor, "batch intrinsic_dim batch"],  # comparisons
     ]:
         """Preprocessing function for the new version of ProductDT.
@@ -502,11 +470,7 @@ class ProductSpaceDT(BasePredictor):
 
         # We have the angle, but ideally we would like the *midpoint* angle.
         # So we need to grab the closest angle from the negative class:
-        angle_comparisons = (
-            comparisons[n, d]
-            if self.batched
-            else _angular_greater(angles[:, d], theta_pos).flatten()
-        )
+        angle_comparisons = comparisons[n, d] if self.batched else _angular_greater(angles[:, d], theta_pos).flatten()
         if (angle_comparisons == 1.0).all():
             theta_neg = theta_pos
         else:
@@ -514,9 +478,7 @@ class ProductSpaceDT(BasePredictor):
             theta_neg = angles[angle_comparisons == 0.0, d][n_neg]
 
         # Get manifold
-        active_dim = (
-            d.item() if self.permutations is None else self.permutations[d].item()
-        )
+        active_dim = d.item() if self.permutations is None else self.permutations[d].item()
         manifold = self.pm.P[self.angle2man[active_dim]]
         special_first_bool = self.special_first[active_dim]
 
@@ -591,9 +553,7 @@ class ProductSpaceDT(BasePredictor):
         """
 
         def _halt(
-            labels: (
-                Float[torch.Tensor, "batch n_classes"] | Real[torch.Tensor, "batch"]
-            ),
+            labels: (Float[torch.Tensor, "batch n_classes"] | Real[torch.Tensor, "batch"]),
         ) -> _DecisionNode:
             """Create a leaf node when halting conditions are met."""
             probs, value = self._leaf_values(labels)
@@ -616,14 +576,8 @@ class ProductSpaceDT(BasePredictor):
             return _halt(labels)
 
         # Get the best split
-        n, d, theta = self._get_best_split(
-            ig=ig, angles=angles, comparisons=comparisons
-        )
-        mask = (
-            comparisons[n, d].bool()
-            if self.batched
-            else _angular_greater(angles[:, d], theta).flatten()
-        )
+        n, d, theta = self._get_best_split(ig=ig, angles=angles, comparisons=comparisons)
+        mask = comparisons[n, d].bool() if self.batched else _angular_greater(angles[:, d], theta).flatten()
         (
             (angles_neg, comparisons_neg, labels_neg),
             (
@@ -663,18 +617,14 @@ class ProductSpaceDT(BasePredictor):
             probs = y.sum(dim=0) / y.sum()
             return probs, probs.argmax()
 
-    def _left(
-        self, angles_row: Float[torch.Tensor, "intrinsic_dim"], node: _DecisionNode
-    ) -> bool:
+    def _left(self, angles_row: Float[torch.Tensor, "intrinsic_dim"], node: _DecisionNode) -> bool:
         """Boolean: Go left? Works on a preprocessed input vector."""
         return _angular_greater(  # type:ignore
             torch.tensor(node.theta, device=angles_row.device).flatten(),
             angles_row[node.feature].flatten(),
         ).item()
 
-    def _traverse(
-        self, x: Float[torch.Tensor, "intrinsic_dim"], node: _DecisionNode
-    ) -> _DecisionNode:
+    def _traverse(self, x: Float[torch.Tensor, "intrinsic_dim"], node: _DecisionNode) -> _DecisionNode:
         """Traverse a decision tree for a single point."""
         # Leaf case
         if node.left is None and node.right is None:
@@ -683,18 +633,14 @@ class ProductSpaceDT(BasePredictor):
         return self._traverse(x, node.left) if self._left(x, node) else self._traverse(x, node.right)  # type: ignore
 
     @torch.no_grad()  # type: ignore
-    def predict_proba(
-        self, X: Float[torch.Tensor, "batch intrinsic_dim"]
-    ) -> Float[torch.Tensor, "batch n_classes"]:
+    def predict_proba(self, X: Float[torch.Tensor, "batch intrinsic_dim"]) -> Float[torch.Tensor, "batch n_classes"]:
         """Predict class probabilities for samples in X."""
         if self.use_special_dims:
             X, _ = self._aggregate_special_dims(X)
         angles, _, _ = self._preprocess(X=X)
         if self.permutations is not None:
             angles = angles[:, self.permutations]
-        return torch.vstack(
-            [self._traverse(angles_row, self.tree).probs for angles_row in angles]
-        )
+        return torch.vstack([self._traverse(angles_row, self.tree).probs for angles_row in angles])
 
 
 class ProductSpaceRF(BasePredictor):
@@ -724,9 +670,7 @@ class ProductSpaceRF(BasePredictor):
 
         # Raise error if manifold is stereographic
         if pm.is_stereographic:
-            raise ValueError(
-                "Stereographic manifolds are not supported. Use a different representation."
-            )
+            raise ValueError("Stereographic manifolds are not supported. Use a different representation.")
         if task == "link_prediction":
             raise ValueError(
                 "Link prediction is not supported for decision trees. Please use utils.link_prediction to reframe as classification"
@@ -739,9 +683,7 @@ class ProductSpaceRF(BasePredictor):
         self.max_depth = tree_kwargs["max_depth"] = max_depth or -1
         self.min_samples_leaf = tree_kwargs["min_samples_leaf"] = min_samples_leaf
         self.min_samples_split = tree_kwargs["min_samples_split"] = min_samples_split
-        self.min_impurity_decrease = tree_kwargs["min_impurity_decrease"] = (
-            min_impurity_decrease
-        )
+        self.min_impurity_decrease = tree_kwargs["min_impurity_decrease"] = min_impurity_decrease
         self.use_special_dims = tree_kwargs["use_special_dims"] = use_special_dims
         self.n_features = tree_kwargs["n_features"] = n_features
         self.batch_size = tree_kwargs["batch_size"] = batch_size
@@ -769,9 +711,7 @@ class ProductSpaceRF(BasePredictor):
 
     def _generate_subsample(
         self, n_rows: int, n_cols: int, n_trees: int
-    ) -> tuple[
-        Int[torch.Tensor, "n_trees n_rows"], Int[torch.Tensor, "n_trees n_cols"]
-    ]:
+    ) -> tuple[Int[torch.Tensor, "n_trees n_rows"], Int[torch.Tensor, "n_trees n_cols"]]:
         # Get number of dimensions in our subsample
         if isinstance(self.max_features, int):
             n_cols_sample = min(self.max_features, n_cols)
@@ -786,9 +726,7 @@ class ProductSpaceRF(BasePredictor):
 
         # Subsample - returns indices
         idx_sample = torch.randint(0, n_rows, (n_trees, n_rows))
-        idx_dim = torch.stack(
-            [torch.randperm(n_cols)[:n_cols_sample] for _ in range(n_trees)]
-        )
+        idx_dim = torch.stack([torch.randperm(n_cols)[:n_cols_sample] for _ in range(n_trees)])
 
         return idx_sample, idx_dim
 
@@ -821,19 +759,13 @@ class ProductSpaceRF(BasePredictor):
 
         # Subsample - just the indices
         n, d = angles.shape
-        idx_sample_all, idx_dim_all = self._generate_subsample(
-            n_rows=n, n_cols=d, n_trees=self.n_estimators
-        )
+        idx_sample_all, idx_dim_all = self._generate_subsample(n_rows=n, n_cols=d, n_trees=self.n_estimators)
 
         # Fit trees
-        for tree, idx_sample, idx_dim in zip(
-            self.trees, idx_sample_all, idx_dim_all, strict=False
-        ):
+        for tree, idx_sample, idx_dim in zip(self.trees, idx_sample_all, idx_dim_all, strict=False):
             tree.permutations = idx_dim
             if self.batched:
-                comparisons_subsample = comparisons[idx_sample][:, idx_dim][
-                    :, :, idx_sample
-                ]
+                comparisons_subsample = comparisons[idx_sample][:, idx_dim][:, :, idx_sample]
             else:
                 comparisons_subsample = comparisons
             tree.tree = tree._fit_node(
@@ -847,8 +779,6 @@ class ProductSpaceRF(BasePredictor):
         return self
 
     @torch.no_grad()  # type: ignore
-    def predict_proba(
-        self, X: Float[torch.Tensor, "batch intrinsic_dim"]
-    ) -> Float[torch.Tensor, "batch n_classes"]:
+    def predict_proba(self, X: Float[torch.Tensor, "batch intrinsic_dim"]) -> Float[torch.Tensor, "batch n_classes"]:
         """Predict class probabilities for samples in X."""
         return torch.stack([tree.predict_proba(X) for tree in self.trees]).mean(dim=0)

--- a/manify/predictors/decision_tree.py
+++ b/manify/predictors/decision_tree.py
@@ -19,8 +19,7 @@ from ._midpoint import midpoint
 
 
 def _angular_greater(
-    queries: Float[torch.Tensor, "query_batch ..."],
-    keys: Float[torch.Tensor, "key_batch ..."],
+    queries: Float[torch.Tensor, "query_batch ..."], keys: Float[torch.Tensor, "key_batch ..."]
 ) -> Bool[torch.Tensor, "query_batch key_batch ..."]:
     r"""Given an angle $\theta$, check whether a tensor of inputs is in $[\theta, \theta + \pi)$.
 
@@ -37,7 +36,7 @@ def _angular_greater(
 
 def _get_info_gains(
     comparisons: Float[torch.Tensor, "query_batch dims key_batch"],
-    labels: (Float[torch.Tensor, "query_batch n_classes"] | Float[torch.Tensor, "query_batch"]),
+    labels: Float[torch.Tensor, "query_batch n_classes"] | Float[torch.Tensor, "query_batch"],
     criterion: Literal["gini", "mse"] = "gini",
     min_values_leaf: int = 1,
     eps: float = 1e-10,
@@ -186,7 +185,7 @@ def _get_split(
     mask: Bool[torch.Tensor, "query_batch"],
     angles: Float[torch.Tensor, "query_batch dims"],
     comparisons: Float[torch.Tensor, "query_batch dims key_batch"],
-    labels: (Float[torch.Tensor, "query_batch n_classes"] | Float[torch.Tensor, "query_batch"]),
+    labels: Float[torch.Tensor, "query_batch n_classes"] | Float[torch.Tensor, "query_batch"],
 ) -> tuple[
     tuple[
         Float[torch.Tensor, "query_batch_neg dims"],
@@ -324,9 +323,7 @@ class ProductSpaceDT(BasePredictor):
         self.signature: list[tuple[float, int]] = pm.signature  # The signature of the manifold
 
     def _preprocess(
-        self,
-        X: Float[torch.Tensor, "batch ambient_dim"],
-        y: Real[torch.Tensor, "batch"] | None = None,
+        self, X: Float[torch.Tensor, "batch ambient_dim"], y: Real[torch.Tensor, "batch"] | None = None
     ) -> tuple[
         Float[torch.Tensor, "batch intrinsic_dim"],  # angles
         Float[torch.Tensor, "batch n_classes"] | Float[torch.Tensor, "batch"] | Float[torch.Tensor, "0"],  # labels
@@ -488,11 +485,7 @@ class ProductSpaceDT(BasePredictor):
         return n, d, m
 
     @torch.no_grad()  # type: ignore
-    def fit(
-        self,
-        X: Float[torch.Tensor, "batch ambient_dim"],
-        y: Real[torch.Tensor, "batch"],
-    ) -> ProductSpaceDT:
+    def fit(self, X: Float[torch.Tensor, "batch ambient_dim"], y: Real[torch.Tensor, "batch"]) -> ProductSpaceDT:
         """Reworked fit function for new version of ProductDT.
 
         Args:
@@ -510,12 +503,7 @@ class ProductSpaceDT(BasePredictor):
         angles, labels, comparisons_reshaped = self._preprocess(X=X, y=y)
 
         # Fit node
-        self.tree = self._fit_node(
-            angles=angles,
-            labels=labels,
-            comparisons=comparisons_reshaped,
-            depth=self.max_depth,
-        )
+        self.tree = self._fit_node(angles=angles, labels=labels, comparisons=comparisons_reshaped, depth=self.max_depth)
 
         self.is_fitted_ = True  # Mark the model as fitted
         return self
@@ -552,9 +540,7 @@ class ProductSpaceDT(BasePredictor):
             node: The decision node created from the fitting process.
         """
 
-        def _halt(
-            labels: (Float[torch.Tensor, "batch n_classes"] | Real[torch.Tensor, "batch"]),
-        ) -> _DecisionNode:
+        def _halt(labels: Float[torch.Tensor, "batch n_classes"] | Real[torch.Tensor, "batch"]) -> _DecisionNode:
             """Create a leaf node when halting conditions are met."""
             probs, value = self._leaf_values(labels)
             node = _DecisionNode(value=value.item(), probs=probs)
@@ -590,26 +576,13 @@ class ProductSpaceDT(BasePredictor):
         self.nodes.append(node)
 
         # Do left and right recursion after appending node to self.nodes (ensures order of self.nodes is correct)
-        node.left = self._fit_node(
-            angles=angles_neg,
-            labels=labels_neg,
-            comparisons=comparisons_neg,
-            depth=depth - 1,
-        )
-        node.right = self._fit_node(
-            angles=angles_pos,
-            labels=labels_pos,
-            comparisons=comparisons_pos,
-            depth=depth - 1,
-        )
+        node.left = self._fit_node(angles=angles_neg, labels=labels_neg, comparisons=comparisons_neg, depth=depth - 1)
+        node.right = self._fit_node(angles=angles_pos, labels=labels_pos, comparisons=comparisons_pos, depth=depth - 1)
         return node
 
     def _leaf_values(
         self, y: Float[torch.Tensor, "batch n_classes"] | Float[torch.Tensor, "batch"]
-    ) -> tuple[
-        Float[torch.Tensor, "n_classes"] | Float[torch.Tensor, ""],
-        Real[torch.Tensor, ""],
-    ]:
+    ) -> tuple[Float[torch.Tensor, "n_classes"] | Float[torch.Tensor, ""], Real[torch.Tensor, ""]]:
         """Get majority class and class probabilities."""
         if self.task == "regression":
             return y.mean(), y.mean()
@@ -620,8 +593,7 @@ class ProductSpaceDT(BasePredictor):
     def _left(self, angles_row: Float[torch.Tensor, "intrinsic_dim"], node: _DecisionNode) -> bool:
         """Boolean: Go left? Works on a preprocessed input vector."""
         return _angular_greater(  # type:ignore
-            torch.tensor(node.theta, device=angles_row.device).flatten(),
-            angles_row[node.feature].flatten(),
+            torch.tensor(node.theta, device=angles_row.device).flatten(), angles_row[node.feature].flatten()
         ).item()
 
     def _traverse(self, x: Float[torch.Tensor, "intrinsic_dim"], node: _DecisionNode) -> _DecisionNode:
@@ -731,11 +703,7 @@ class ProductSpaceRF(BasePredictor):
         return idx_sample, idx_dim
 
     @torch.no_grad()  # type: ignore
-    def fit(
-        self,
-        X: Float[torch.Tensor, "batch ambient_dim"],
-        y: Real[torch.Tensor, "batch"],
-    ) -> ProductSpaceRF:
+    def fit(self, X: Float[torch.Tensor, "batch ambient_dim"], y: Real[torch.Tensor, "batch"]) -> ProductSpaceRF:
         """Preprocess and fit an ensemble of trees on subsampled data."""
         # Pre-preprocessing step: aggregate special dimensions
         if self.use_special_dims:

--- a/manify/predictors/decision_tree.py
+++ b/manify/predictors/decision_tree.py
@@ -19,7 +19,8 @@ from ._midpoint import midpoint
 
 
 def _angular_greater(
-    queries: Float[torch.Tensor, "query_batch ..."], keys: Float[torch.Tensor, "key_batch ..."]
+    queries: Float[torch.Tensor, "query_batch ..."],
+    keys: Float[torch.Tensor, "key_batch ..."],
 ) -> Bool[torch.Tensor, "query_batch key_batch ..."]:
     r"""Given an angle $\theta$, check whether a tensor of inputs is in $[\theta, \theta + \pi)$.
 
@@ -36,7 +37,10 @@ def _angular_greater(
 
 def _get_info_gains(
     comparisons: Float[torch.Tensor, "query_batch dims key_batch"],
-    labels: Float[torch.Tensor, "query_batch n_classes"] | Float[torch.Tensor, "query_batch"],
+    labels: (
+        Float[torch.Tensor, "query_batch n_classes"]
+        | Float[torch.Tensor, "query_batch"]
+    ),
     criterion: Literal["gini", "mse"] = "gini",
     min_values_leaf: int = 1,
     eps: float = 1e-10,
@@ -133,15 +137,21 @@ def _get_info_gains_nobatch(
     """
     # Matrix-multiply to get counts of labels in left and right splits
     if criterion == "gini":
-        pos_labels = torch.zeros((angles.shape[0], angles.shape[1], labels.shape[1]), device=angles.device)
-        neg_labels = torch.zeros((angles.shape[0], angles.shape[1], labels.shape[1]), device=angles.device)
+        pos_labels = torch.zeros(
+            (angles.shape[0], angles.shape[1], labels.shape[1]), device=angles.device
+        )
+        neg_labels = torch.zeros(
+            (angles.shape[0], angles.shape[1], labels.shape[1]), device=angles.device
+        )
 
         for d in range(angles.shape[1]):
             for j in range(0, angles.shape[0]):
                 mask = _angular_greater(angles[:, d], angles[j, d])
 
                 # Expanding the labels to match the broadcasting needs of the mask
-                pos_labels_entry = mask.float() * labels  # [batch_size, labels.shape[1]]
+                pos_labels_entry = (
+                    mask.float() * labels
+                )  # [batch_size, labels.shape[1]]
                 neg_labels_entry = ~mask * labels  # [batch_size, labels.shape[1]]
 
                 # Assign the calculated values to the respective positions in the final tensors
@@ -185,17 +195,22 @@ def _get_split(
     mask: Bool[torch.Tensor, "query_batch"],
     angles: Float[torch.Tensor, "query_batch dims"],
     comparisons: Float[torch.Tensor, "query_batch dims key_batch"],
-    labels: Float[torch.Tensor, "query_batch n_classes"] | Float[torch.Tensor, "query_batch"],
+    labels: (
+        Float[torch.Tensor, "query_batch n_classes"]
+        | Float[torch.Tensor, "query_batch"]
+    ),
 ) -> tuple[
     tuple[
         Float[torch.Tensor, "query_batch_neg dims"],
         Float[torch.Tensor, "query_batch_neg dims query_batch_neg"],
-        Float[torch.Tensor, "query_batch_neg n_classes"] | Float[torch.Tensor, "query_batch_neg"],
+        Float[torch.Tensor, "query_batch_neg n_classes"]
+        | Float[torch.Tensor, "query_batch_neg"],
     ],
     tuple[
         Float[torch.Tensor, "query_batch_pos dims"],
         Float[torch.Tensor, "query_batch_pos dims query_batch_pos"],
-        Float[torch.Tensor, "query_batch_pos n_classes"] | Float[torch.Tensor, "query_batch_pos"],
+        Float[torch.Tensor, "query_batch_pos n_classes"]
+        | Float[torch.Tensor, "query_batch_pos"],
     ],
 ]:
     """Split tensors into negative and positive classes based on the mask.
@@ -271,7 +286,9 @@ class ProductSpaceDT(BasePredictor):
         min_samples_leaf: int = 1,
         min_samples_split: int = 2,
         min_impurity_decrease: float = 0.0,
-        task: Literal["classification", "regression", "link_prediction"] = "classification",
+        task: Literal[
+            "classification", "regression", "link_prediction"
+        ] = "classification",
         use_special_dims: bool = False,
         batch_size: int | None = None,
         n_features: Literal["d", "d_choose_2"] = "d",
@@ -284,7 +301,9 @@ class ProductSpaceDT(BasePredictor):
 
         # Raise error if manifold is stereographic
         if pm.is_stereographic:
-            raise ValueError("Stereographic manifolds are not supported. Use a different representation.")
+            raise ValueError(
+                "Stereographic manifolds are not supported. Use a different representation."
+            )
         if task == "link_prediction":
             raise ValueError(
                 "Link prediction is not supported for decision trees. Please use utils.link_prediction to reframe as classification"
@@ -313,20 +332,36 @@ class ProductSpaceDT(BasePredictor):
 
         # These will become important later, when fit is called
         self.nodes: list[_DecisionNode] = []  # For fitted nodes
-        self.permutations: Int[torch.Tensor, "n_classes"] | None = None  # If used as part of a random forest
+        self.permutations: Int[torch.Tensor, "n_classes"] | None = (
+            None  # If used as part of a random forest
+        )
         self.angle2man: list[int] = []  # Maps preprocessed angles to manifold indices
-        self.special_first: list[bool] = []  # Whether the first dimension is special in a projection
-        self.angle_dims: list[tuple[int, int]] = []  # Maps preprocessed angles to dimension indices
+        self.special_first: list[bool] = (
+            []
+        )  # Whether the first dimension is special in a projection
+        self.angle_dims: list[tuple[int, int]] = (
+            []
+        )  # Maps preprocessed angles to dimension indices
         self.tree: _DecisionNode = _DecisionNode()  # The root of the tree
-        self.classes_: Float[torch.Tensor, "n_classes"] = torch.empty(0)  # Initialize as an empty tensor
-        self.labels_: Int[torch.Tensor, "batch n_classes"] = torch.tensor([])  # sklearn-style labels
-        self.signature: list[tuple[float, int]] = pm.signature  # The signature of the manifold
+        self.classes_: Float[torch.Tensor, "n_classes"] = torch.empty(
+            0
+        )  # Initialize as an empty tensor
+        self.labels_: Int[torch.Tensor, "batch n_classes"] = torch.tensor(
+            []
+        )  # sklearn-style labels
+        self.signature: list[tuple[float, int]] = (
+            pm.signature
+        )  # The signature of the manifold
 
     def _preprocess(
-        self, X: Float[torch.Tensor, "batch ambient_dim"], y: Real[torch.Tensor, "batch"] | None = None
+        self,
+        X: Float[torch.Tensor, "batch ambient_dim"],
+        y: Real[torch.Tensor, "batch"] | None = None,
     ) -> tuple[
         Float[torch.Tensor, "batch intrinsic_dim"],  # angles
-        Float[torch.Tensor, "batch n_classes"] | Float[torch.Tensor, "batch"] | Float[torch.Tensor, "0"],  # labels
+        Float[torch.Tensor, "batch n_classes"]
+        | Float[torch.Tensor, "batch"]
+        | Float[torch.Tensor, "0"],  # labels
         Float[torch.Tensor, "batch intrinsic_dim batch"],  # comparisons
     ]:
         """Preprocessing function for the new version of ProductDT.
@@ -467,7 +502,11 @@ class ProductSpaceDT(BasePredictor):
 
         # We have the angle, but ideally we would like the *midpoint* angle.
         # So we need to grab the closest angle from the negative class:
-        angle_comparisons = comparisons[n, d] if self.batched else _angular_greater(angles[:, d], theta_pos).flatten()
+        angle_comparisons = (
+            comparisons[n, d]
+            if self.batched
+            else _angular_greater(angles[:, d], theta_pos).flatten()
+        )
         if (angle_comparisons == 1.0).all():
             theta_neg = theta_pos
         else:
@@ -475,7 +514,9 @@ class ProductSpaceDT(BasePredictor):
             theta_neg = angles[angle_comparisons == 0.0, d][n_neg]
 
         # Get manifold
-        active_dim = d.item() if self.permutations is None else self.permutations[d].item()
+        active_dim = (
+            d.item() if self.permutations is None else self.permutations[d].item()
+        )
         manifold = self.pm.P[self.angle2man[active_dim]]
         special_first_bool = self.special_first[active_dim]
 
@@ -485,7 +526,11 @@ class ProductSpaceDT(BasePredictor):
         return n, d, m
 
     @torch.no_grad()  # type: ignore
-    def fit(self, X: Float[torch.Tensor, "batch ambient_dim"], y: Real[torch.Tensor, "batch"]) -> ProductSpaceDT:
+    def fit(
+        self,
+        X: Float[torch.Tensor, "batch ambient_dim"],
+        y: Real[torch.Tensor, "batch"],
+    ) -> ProductSpaceDT:
         """Reworked fit function for new version of ProductDT.
 
         Args:
@@ -503,7 +548,12 @@ class ProductSpaceDT(BasePredictor):
         angles, labels, comparisons_reshaped = self._preprocess(X=X, y=y)
 
         # Fit node
-        self.tree = self._fit_node(angles=angles, labels=labels, comparisons=comparisons_reshaped, depth=self.max_depth)
+        self.tree = self._fit_node(
+            angles=angles,
+            labels=labels,
+            comparisons=comparisons_reshaped,
+            depth=self.max_depth,
+        )
 
         self.is_fitted_ = True  # Mark the model as fitted
         return self
@@ -540,7 +590,11 @@ class ProductSpaceDT(BasePredictor):
             node: The decision node created from the fitting process.
         """
 
-        def _halt(labels: Float[torch.Tensor, "batch n_classes"] | Real[torch.Tensor, "batch"]) -> _DecisionNode:
+        def _halt(
+            labels: (
+                Float[torch.Tensor, "batch n_classes"] | Real[torch.Tensor, "batch"]
+            ),
+        ) -> _DecisionNode:
             """Create a leaf node when halting conditions are met."""
             probs, value = self._leaf_values(labels)
             node = _DecisionNode(value=value.item(), probs=probs)
@@ -562,8 +616,14 @@ class ProductSpaceDT(BasePredictor):
             return _halt(labels)
 
         # Get the best split
-        n, d, theta = self._get_best_split(ig=ig, angles=angles, comparisons=comparisons)
-        mask = comparisons[n, d].bool() if self.batched else _angular_greater(angles[:, d], theta).flatten()
+        n, d, theta = self._get_best_split(
+            ig=ig, angles=angles, comparisons=comparisons
+        )
+        mask = (
+            comparisons[n, d].bool()
+            if self.batched
+            else _angular_greater(angles[:, d], theta).flatten()
+        )
         (
             (angles_neg, comparisons_neg, labels_neg),
             (
@@ -576,13 +636,26 @@ class ProductSpaceDT(BasePredictor):
         self.nodes.append(node)
 
         # Do left and right recursion after appending node to self.nodes (ensures order of self.nodes is correct)
-        node.left = self._fit_node(angles=angles_neg, labels=labels_neg, comparisons=comparisons_neg, depth=depth - 1)
-        node.right = self._fit_node(angles=angles_pos, labels=labels_pos, comparisons=comparisons_pos, depth=depth - 1)
+        node.left = self._fit_node(
+            angles=angles_neg,
+            labels=labels_neg,
+            comparisons=comparisons_neg,
+            depth=depth - 1,
+        )
+        node.right = self._fit_node(
+            angles=angles_pos,
+            labels=labels_pos,
+            comparisons=comparisons_pos,
+            depth=depth - 1,
+        )
         return node
 
     def _leaf_values(
         self, y: Float[torch.Tensor, "batch n_classes"] | Float[torch.Tensor, "batch"]
-    ) -> tuple[Float[torch.Tensor, "n_classes"] | Float[torch.Tensor, ""], Real[torch.Tensor, ""]]:
+    ) -> tuple[
+        Float[torch.Tensor, "n_classes"] | Float[torch.Tensor, ""],
+        Real[torch.Tensor, ""],
+    ]:
         """Get majority class and class probabilities."""
         if self.task == "regression":
             return y.mean(), y.mean()
@@ -590,13 +663,18 @@ class ProductSpaceDT(BasePredictor):
             probs = y.sum(dim=0) / y.sum()
             return probs, probs.argmax()
 
-    def _left(self, angles_row: Float[torch.Tensor, "intrinsic_dim"], node: _DecisionNode) -> bool:
+    def _left(
+        self, angles_row: Float[torch.Tensor, "intrinsic_dim"], node: _DecisionNode
+    ) -> bool:
         """Boolean: Go left? Works on a preprocessed input vector."""
         return _angular_greater(  # type:ignore
-            torch.tensor(node.theta, device=angles_row.device).flatten(), angles_row[node.feature].flatten()
+            torch.tensor(node.theta, device=angles_row.device).flatten(),
+            angles_row[node.feature].flatten(),
         ).item()
 
-    def _traverse(self, x: Float[torch.Tensor, "intrinsic_dim"], node: _DecisionNode) -> _DecisionNode:
+    def _traverse(
+        self, x: Float[torch.Tensor, "intrinsic_dim"], node: _DecisionNode
+    ) -> _DecisionNode:
         """Traverse a decision tree for a single point."""
         # Leaf case
         if node.left is None and node.right is None:
@@ -605,14 +683,18 @@ class ProductSpaceDT(BasePredictor):
         return self._traverse(x, node.left) if self._left(x, node) else self._traverse(x, node.right)  # type: ignore
 
     @torch.no_grad()  # type: ignore
-    def predict_proba(self, X: Float[torch.Tensor, "batch intrinsic_dim"]) -> Float[torch.Tensor, "batch n_classes"]:
+    def predict_proba(
+        self, X: Float[torch.Tensor, "batch intrinsic_dim"]
+    ) -> Float[torch.Tensor, "batch n_classes"]:
         """Predict class probabilities for samples in X."""
         if self.use_special_dims:
             X, _ = self._aggregate_special_dims(X)
         angles, _, _ = self._preprocess(X=X)
         if self.permutations is not None:
             angles = angles[:, self.permutations]
-        return torch.vstack([self._traverse(angles_row, self.tree).probs for angles_row in angles])
+        return torch.vstack(
+            [self._traverse(angles_row, self.tree).probs for angles_row in angles]
+        )
 
 
 class ProductSpaceRF(BasePredictor):
@@ -630,7 +712,7 @@ class ProductSpaceRF(BasePredictor):
         min_impurity_decrease: float = 0.0,
         ablate_midpoints: bool = False,
         n_estimators: int = 100,
-        max_features: Literal["sqrt", "log2", "none"] = "sqrt",
+        max_features: int | Literal["sqrt", "log2", "none"] = "sqrt",
         max_samples: float = 1.0,
         batch_size: int | None = None,
         random_state: int | None = None,
@@ -642,7 +724,9 @@ class ProductSpaceRF(BasePredictor):
 
         # Raise error if manifold is stereographic
         if pm.is_stereographic:
-            raise ValueError("Stereographic manifolds are not supported. Use a different representation.")
+            raise ValueError(
+                "Stereographic manifolds are not supported. Use a different representation."
+            )
         if task == "link_prediction":
             raise ValueError(
                 "Link prediction is not supported for decision trees. Please use utils.link_prediction to reframe as classification"
@@ -655,7 +739,9 @@ class ProductSpaceRF(BasePredictor):
         self.max_depth = tree_kwargs["max_depth"] = max_depth or -1
         self.min_samples_leaf = tree_kwargs["min_samples_leaf"] = min_samples_leaf
         self.min_samples_split = tree_kwargs["min_samples_split"] = min_samples_split
-        self.min_impurity_decrease = tree_kwargs["min_impurity_decrease"] = min_impurity_decrease
+        self.min_impurity_decrease = tree_kwargs["min_impurity_decrease"] = (
+            min_impurity_decrease
+        )
         self.use_special_dims = tree_kwargs["use_special_dims"] = use_special_dims
         self.n_features = tree_kwargs["n_features"] = n_features
         self.batch_size = tree_kwargs["batch_size"] = batch_size
@@ -683,10 +769,12 @@ class ProductSpaceRF(BasePredictor):
 
     def _generate_subsample(
         self, n_rows: int, n_cols: int, n_trees: int
-    ) -> tuple[Int[torch.Tensor, "n_trees n_rows"], Int[torch.Tensor, "n_trees n_cols"]]:
+    ) -> tuple[
+        Int[torch.Tensor, "n_trees n_rows"], Int[torch.Tensor, "n_trees n_cols"]
+    ]:
         # Get number of dimensions in our subsample
-        if isinstance(self.max_features, int) and self.max_features <= n_cols:
-            n_cols_sample = n_cols
+        if isinstance(self.max_features, int):
+            n_cols_sample = min(self.max_features, n_cols)
         elif self.max_features == "sqrt":
             n_cols_sample = torch.ceil(torch.tensor(n_cols**0.5)).int()
         elif self.max_features == "log2":
@@ -698,12 +786,18 @@ class ProductSpaceRF(BasePredictor):
 
         # Subsample - returns indices
         idx_sample = torch.randint(0, n_rows, (n_trees, n_rows))
-        idx_dim = torch.stack([torch.randperm(n_cols)[:n_cols_sample] for _ in range(n_trees)])
+        idx_dim = torch.stack(
+            [torch.randperm(n_cols)[:n_cols_sample] for _ in range(n_trees)]
+        )
 
         return idx_sample, idx_dim
 
     @torch.no_grad()  # type: ignore
-    def fit(self, X: Float[torch.Tensor, "batch ambient_dim"], y: Real[torch.Tensor, "batch"]) -> ProductSpaceRF:
+    def fit(
+        self,
+        X: Float[torch.Tensor, "batch ambient_dim"],
+        y: Real[torch.Tensor, "batch"],
+    ) -> ProductSpaceRF:
         """Preprocess and fit an ensemble of trees on subsampled data."""
         # Pre-preprocessing step: aggregate special dimensions
         if self.use_special_dims:
@@ -727,13 +821,19 @@ class ProductSpaceRF(BasePredictor):
 
         # Subsample - just the indices
         n, d = angles.shape
-        idx_sample_all, idx_dim_all = self._generate_subsample(n_rows=n, n_cols=d, n_trees=self.n_estimators)
+        idx_sample_all, idx_dim_all = self._generate_subsample(
+            n_rows=n, n_cols=d, n_trees=self.n_estimators
+        )
 
         # Fit trees
-        for tree, idx_sample, idx_dim in zip(self.trees, idx_sample_all, idx_dim_all, strict=False):
+        for tree, idx_sample, idx_dim in zip(
+            self.trees, idx_sample_all, idx_dim_all, strict=False
+        ):
             tree.permutations = idx_dim
             if self.batched:
-                comparisons_subsample = comparisons[idx_sample][:, idx_dim][:, :, idx_sample]
+                comparisons_subsample = comparisons[idx_sample][:, idx_dim][
+                    :, :, idx_sample
+                ]
             else:
                 comparisons_subsample = comparisons
             tree.tree = tree._fit_node(
@@ -747,6 +847,8 @@ class ProductSpaceRF(BasePredictor):
         return self
 
     @torch.no_grad()  # type: ignore
-    def predict_proba(self, X: Float[torch.Tensor, "batch intrinsic_dim"]) -> Float[torch.Tensor, "batch n_classes"]:
+    def predict_proba(
+        self, X: Float[torch.Tensor, "batch intrinsic_dim"]
+    ) -> Float[torch.Tensor, "batch n_classes"]:
         """Predict class probabilities for samples in X."""
         return torch.stack([tree.predict_proba(X) for tree in self.trees]).mean(dim=0)

--- a/manify/predictors/decision_tree.py
+++ b/manify/predictors/decision_tree.py
@@ -733,7 +733,7 @@ class ProductSpaceRF(BasePredictor):
             )
 
         # Tree hyperparameters
-        tree_kwargs: Dict[str, Any] = {}
+        tree_kwargs: dict[str, Any] = {}
         self.pm = tree_kwargs["pm"] = pm
         self.task = tree_kwargs["task"] = task
         self.max_depth = tree_kwargs["max_depth"] = max_depth or -1

--- a/manify/predictors/kappa_gcn.py
+++ b/manify/predictors/kappa_gcn.py
@@ -24,7 +24,9 @@ else:
 
 
 def get_A_hat(
-    A: Float[torch.Tensor, "n_nodes n_nodes"], make_symmetric: bool = True, add_self_loops: bool = True
+    A: Float[torch.Tensor, "n_nodes n_nodes"],
+    make_symmetric: bool = True,
+    add_self_loops: bool = True,
 ) -> Float[torch.Tensor, "n_nodes n_nodes"]:
     """Normalize adjacency matrix.
 
@@ -36,13 +38,15 @@ def get_A_hat(
     Returns:
         A_hat: Normalized adjacency matrix.
     """
-    # Fix nans
-    A[torch.isnan(A)] = 0
+    # Fix nans (without mutating the caller's tensor)
+    A = torch.where(torch.isnan(A), torch.zeros_like(A), A)
 
     # Optional steps to make symmetric and add self-loops
     if make_symmetric and not torch.allclose(A, A.T):
         A = A + A.T
-    if add_self_loops and not torch.allclose(torch.diag(A), torch.ones(A.shape[0], dtype=A.dtype, device=A.device)):
+    if add_self_loops and not torch.allclose(
+        torch.diag(A), torch.ones(A.shape[0], dtype=A.dtype, device=A.device)
+    ):
         A = A + torch.eye(A.shape[0], device=A.device, dtype=A.dtype)
 
     # Get degree matrix
@@ -90,11 +94,15 @@ class KappaGCN(BasePredictor, torch.nn.Module):
         output_dim: int,
         num_hidden: int = 2,
         nonlinearity: Callable = torch.relu,
-        task: Literal["classification", "regression", "link_prediction"] = "classification",
+        task: Literal[
+            "classification", "regression", "link_prediction"
+        ] = "classification",
         random_state: int | None = None,
         device: str | None = None,
     ):
-        BasePredictor.__init__(self, pm=pm, task=task, random_state=random_state, device=device)
+        BasePredictor.__init__(
+            self, pm=pm, task=task, random_state=random_state, device=device
+        )
         torch.nn.Module.__init__(self)
 
         self.pm = pm
@@ -180,7 +188,11 @@ class KappaGCN(BasePredictor, torch.nn.Module):
         A = A.clone() if A is not None else None
 
         # Convert A to A_hat
-        A_hat = get_A_hat(A, make_symmetric=True, add_self_loops=True) if A is not None else None
+        A_hat = (
+            get_A_hat(A, make_symmetric=True, add_self_loops=True)
+            if A is not None
+            else None
+        )
 
         # Collect all paramters
         euclidean_params = []
@@ -195,7 +207,11 @@ class KappaGCN(BasePredictor, torch.nn.Module):
 
         # Optimizers
         opt = torch.optim.Adam(euclidean_params, lr=lr)
-        ropt = geoopt.optim.RiemannianAdam(riemannian_params, lr=lr) if riemannian_params else None
+        ropt = (
+            geoopt.optim.RiemannianAdam(riemannian_params, lr=lr)
+            if riemannian_params
+            else None
+        )
 
         if self.task == "classification":
             loss_fn = torch.nn.CrossEntropyLoss()
@@ -229,7 +245,9 @@ class KappaGCN(BasePredictor, torch.nn.Module):
             # Progress bar
             if use_tqdm:
                 my_tqdm.update(1)
-                my_tqdm.set_description(f"Epoch {i + 1}/{epochs}, Loss: {loss.item():.4f}")
+                my_tqdm.set_description(
+                    f"Epoch {i + 1}/{epochs}, Loss: {loss.item():.4f}"
+                )
 
             # Early termination for nan loss
             if torch.isnan(loss):
@@ -245,7 +263,9 @@ class KappaGCN(BasePredictor, torch.nn.Module):
         return self
 
     def predict_proba(
-        self, X: Float[torch.Tensor, "n_nodes dim"], A: Float[torch.Tensor, "n_nodes n_nodes"] | None = None
+        self,
+        X: Float[torch.Tensor, "n_nodes dim"],
+        A: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
     ) -> Real[torch.Tensor, "n_nodes n_classes"] | Real[torch.Tensor, "n_nodes"]:
         """Predict class probabilities using the trained Kappa GCN.
 
@@ -259,7 +279,11 @@ class KappaGCN(BasePredictor, torch.nn.Module):
         # Copy everything
         X = X.clone()
         A = A.clone() if A is not None else None
-        A_hat = get_A_hat(A, make_symmetric=True, add_self_loops=True) if A is not None else None
+        A_hat = (
+            get_A_hat(A, make_symmetric=True, add_self_loops=True)
+            if A is not None
+            else None
+        )
 
         # Get edges for test set
         self.eval()

--- a/manify/predictors/kappa_gcn.py
+++ b/manify/predictors/kappa_gcn.py
@@ -24,9 +24,7 @@ else:
 
 
 def get_A_hat(
-    A: Float[torch.Tensor, "n_nodes n_nodes"],
-    make_symmetric: bool = True,
-    add_self_loops: bool = True,
+    A: Float[torch.Tensor, "n_nodes n_nodes"], make_symmetric: bool = True, add_self_loops: bool = True
 ) -> Float[torch.Tensor, "n_nodes n_nodes"]:
     """Normalize adjacency matrix.
 
@@ -247,9 +245,7 @@ class KappaGCN(BasePredictor, torch.nn.Module):
         return self
 
     def predict_proba(
-        self,
-        X: Float[torch.Tensor, "n_nodes dim"],
-        A: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
+        self, X: Float[torch.Tensor, "n_nodes dim"], A: Float[torch.Tensor, "n_nodes n_nodes"] | None = None
     ) -> Real[torch.Tensor, "n_nodes n_classes"] | Real[torch.Tensor, "n_nodes"]:
         """Predict class probabilities using the trained Kappa GCN.
 

--- a/manify/predictors/kappa_gcn.py
+++ b/manify/predictors/kappa_gcn.py
@@ -44,9 +44,7 @@ def get_A_hat(
     # Optional steps to make symmetric and add self-loops
     if make_symmetric and not torch.allclose(A, A.T):
         A = A + A.T
-    if add_self_loops and not torch.allclose(
-        torch.diag(A), torch.ones(A.shape[0], dtype=A.dtype, device=A.device)
-    ):
+    if add_self_loops and not torch.allclose(torch.diag(A), torch.ones(A.shape[0], dtype=A.dtype, device=A.device)):
         A = A + torch.eye(A.shape[0], device=A.device, dtype=A.dtype)
 
     # Get degree matrix
@@ -94,15 +92,11 @@ class KappaGCN(BasePredictor, torch.nn.Module):
         output_dim: int,
         num_hidden: int = 2,
         nonlinearity: Callable = torch.relu,
-        task: Literal[
-            "classification", "regression", "link_prediction"
-        ] = "classification",
+        task: Literal["classification", "regression", "link_prediction"] = "classification",
         random_state: int | None = None,
         device: str | None = None,
     ):
-        BasePredictor.__init__(
-            self, pm=pm, task=task, random_state=random_state, device=device
-        )
+        BasePredictor.__init__(self, pm=pm, task=task, random_state=random_state, device=device)
         torch.nn.Module.__init__(self)
 
         self.pm = pm
@@ -188,11 +182,7 @@ class KappaGCN(BasePredictor, torch.nn.Module):
         A = A.clone() if A is not None else None
 
         # Convert A to A_hat
-        A_hat = (
-            get_A_hat(A, make_symmetric=True, add_self_loops=True)
-            if A is not None
-            else None
-        )
+        A_hat = get_A_hat(A, make_symmetric=True, add_self_loops=True) if A is not None else None
 
         # Collect all paramters
         euclidean_params = []
@@ -207,11 +197,7 @@ class KappaGCN(BasePredictor, torch.nn.Module):
 
         # Optimizers
         opt = torch.optim.Adam(euclidean_params, lr=lr)
-        ropt = (
-            geoopt.optim.RiemannianAdam(riemannian_params, lr=lr)
-            if riemannian_params
-            else None
-        )
+        ropt = geoopt.optim.RiemannianAdam(riemannian_params, lr=lr) if riemannian_params else None
 
         if self.task == "classification":
             loss_fn = torch.nn.CrossEntropyLoss()
@@ -245,9 +231,7 @@ class KappaGCN(BasePredictor, torch.nn.Module):
             # Progress bar
             if use_tqdm:
                 my_tqdm.update(1)
-                my_tqdm.set_description(
-                    f"Epoch {i + 1}/{epochs}, Loss: {loss.item():.4f}"
-                )
+                my_tqdm.set_description(f"Epoch {i + 1}/{epochs}, Loss: {loss.item():.4f}")
 
             # Early termination for nan loss
             if torch.isnan(loss):
@@ -279,11 +263,7 @@ class KappaGCN(BasePredictor, torch.nn.Module):
         # Copy everything
         X = X.clone()
         A = A.clone() if A is not None else None
-        A_hat = (
-            get_A_hat(A, make_symmetric=True, add_self_loops=True)
-            if A is not None
-            else None
-        )
+        A_hat = get_A_hat(A, make_symmetric=True, add_self_loops=True) if A is not None else None
 
         # Get edges for test set
         self.eval()

--- a/manify/predictors/nn/layers.py
+++ b/manify/predictors/nn/layers.py
@@ -395,7 +395,7 @@ class StereographicLayerNorm(nn.Module):
         self,
         manifold: Manifold | ProductManifold,
         embedding_dim: int,
-        curvatures: torch.Tensor["num_heads 1 1"],
+        curvatures: Float[torch.Tensor, "num_heads 1 1"],
     ):
         super().__init__()
 

--- a/manify/predictors/nn/layers.py
+++ b/manify/predictors/nn/layers.py
@@ -31,11 +31,7 @@ class KappaGCNLayer(torch.nn.Module):
     """
 
     def __init__(
-        self,
-        in_features: int,
-        out_features: int,
-        manifold: Manifold,
-        nonlinearity: Callable | None = torch.relu,
+        self, in_features: int, out_features: int, manifold: Manifold, nonlinearity: Callable | None = torch.relu
     ):
         super().__init__()
 
@@ -49,10 +45,7 @@ class KappaGCNLayer(torch.nn.Module):
         self.manifold = manifold
 
     def _left_multiply(
-        self,
-        A: Float[torch.Tensor, "n_nodes n_nodes"],
-        X: Float[torch.Tensor, "n_nodes dim"],
-        M: Manifold,
+        self, A: Float[torch.Tensor, "n_nodes n_nodes"], X: Float[torch.Tensor, "n_nodes dim"], M: Manifold
     ) -> Float[torch.Tensor, "n_nodes dim"]:
         r"""$\kappa$-left matrix multiply two matrices $\mathbf{A}$ and $\mathbf{X}$.
 
@@ -78,9 +71,7 @@ class KappaGCNLayer(torch.nn.Module):
         )
 
     def forward(
-        self,
-        X: Float[torch.Tensor, "n_nodes dim"],
-        A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
+        self, X: Float[torch.Tensor, "n_nodes dim"], A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None
     ) -> Float[torch.Tensor, "n_nodes dim"]:
         """Forward pass for the Kappa GCN layer.
 
@@ -125,9 +116,7 @@ class KappaSequential(nn.Module):
         self.layers = nn.ModuleList(layers)
 
     def forward(
-        self,
-        X: Float[torch.Tensor, "n_nodes dim"],
-        A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
+        self, X: Float[torch.Tensor, "n_nodes dim"], A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None
     ) -> Float[torch.Tensor, "n_nodes out_dim"]:
         """Forward pass through all layers.
 
@@ -178,12 +167,7 @@ class StereographicLogits(nn.Module):
         apply_softmax: Whether to apply softmax to the output logits (default: False)
     """
 
-    def __init__(
-        self,
-        out_features: int,
-        manifold: Manifold | ProductManifold,
-        apply_softmax: bool = False,
-    ):
+    def __init__(self, out_features: int, manifold: Manifold | ProductManifold, apply_softmax: bool = False):
         super().__init__()
 
         self.out_features = out_features
@@ -204,10 +188,7 @@ class StereographicLogits(nn.Module):
         M: Manifold,
         return_inner_products: bool = False,
     ) -> (
-        tuple[
-            Float[torch.Tensor, "n_nodes n_classes"],
-            Float[torch.Tensor, "n_nodes n_classes"],
-        ]
+        tuple[Float[torch.Tensor, "n_nodes n_classes"], Float[torch.Tensor, "n_nodes n_classes"]]
         | Float[torch.Tensor, "n_nodes n_classes"]
     ):
         """Compute logits for a single manifold."""
@@ -377,10 +358,7 @@ class StereographicLayerNorm(nn.Module):
     """
 
     def __init__(
-        self,
-        manifold: Manifold | ProductManifold,
-        embedding_dim: int,
-        curvatures: Float[torch.Tensor, "num_heads 1 1"],
+        self, manifold: Manifold | ProductManifold, embedding_dim: int, curvatures: Float[torch.Tensor, "num_heads 1 1"]
     ):
         super().__init__()
 
@@ -459,10 +437,7 @@ class GeometricLinearizedAttention(nn.Module):
 
         X = geoopt.manifolds.stereographic.math.project(X, k=self.curvatures)
         X = geoopt.manifolds.stereographic.math.mobius_scalar_mul(
-            torch.tensor(0.5, dtype=X.dtype, device=X.device),
-            X,
-            k=self.curvatures,
-            dim=-1,
+            torch.tensor(0.5, dtype=X.dtype, device=X.device), X, k=self.curvatures, dim=-1
         )
         X = geoopt.manifolds.stereographic.math.project(X, k=self.curvatures)
 
@@ -491,13 +466,7 @@ class StereographicAttention(nn.Module):
         ff: Manifold-aware linear layer for the feedforward output.
     """
 
-    def __init__(
-        self,
-        manifold: Manifold | ProductManifold,
-        num_heads: int,
-        dim: int,
-        head_dim: int,
-    ):
+    def __init__(self, manifold: Manifold | ProductManifold, num_heads: int, dim: int, head_dim: int):
         super().__init__()
 
         self.manifold = manifold
@@ -507,20 +476,12 @@ class StereographicAttention(nn.Module):
 
         self.W_q = nn.Linear(in_features=dim, out_features=self.num_heads * self.head_dim)
         self.W_k = nn.Linear(in_features=dim, out_features=self.num_heads * self.head_dim)
-        self.W_v = KappaGCNLayer(
-            in_features=dim,
-            out_features=self.num_heads * self.head_dim,
-            manifold=self.manifold,
-        )
+        self.W_v = KappaGCNLayer(in_features=dim, out_features=self.num_heads * self.head_dim, manifold=self.manifold)
 
         self.attn = GeometricLinearizedAttention(
             curvatures=self.curvatures, num_heads=self.num_heads, head_dim=self.head_dim
         )
-        self.ff = KappaGCNLayer(
-            in_features=self.num_heads * self.head_dim,
-            out_features=dim,
-            manifold=self.manifold,
-        )
+        self.ff = KappaGCNLayer(in_features=self.num_heads * self.head_dim, out_features=dim, manifold=self.manifold)
 
     def forward(
         self,
@@ -591,12 +552,7 @@ class StereographicTransformer(nn.Module):
     """
 
     def __init__(
-        self,
-        manifold: Manifold | ProductManifold,
-        num_heads: int,
-        dim: int,
-        head_dim: int,
-        use_layer_norm: bool = True,
+        self, manifold: Manifold | ProductManifold, num_heads: int, dim: int, head_dim: int, use_layer_norm: bool = True
     ):
         super().__init__()
 

--- a/manify/predictors/nn/layers.py
+++ b/manify/predictors/nn/layers.py
@@ -99,12 +99,7 @@ class KappaGCNLayer(torch.nn.Module):
             AXW = XW
         elif isinstance(self.manifold, ProductManifold):
             XWs = self.manifold.factorize(XW)
-            AXW = torch.hstack(
-                [
-                    self._left_multiply(A_hat, XW, M)
-                    for XW, M in zip(XWs, self.manifold.P, strict=False)
-                ]
-            )
+            AXW = torch.hstack([self._left_multiply(A_hat, XW, M) for XW, M in zip(XWs, self.manifold.P, strict=False)])
         else:
             AXW = self._left_multiply(A_hat, XW, self.manifold)
 
@@ -199,9 +194,7 @@ class StereographicLogits(nn.Module):
         self.W = nn.Parameter(torch.randn(manifold.dim, out_features) * 0.01)
 
         # Bias points on the manifold
-        self.p_ks = geoopt.ManifoldParameter(
-            torch.zeros(out_features, manifold.dim), manifold=manifold.manifold
-        )
+        self.p_ks = geoopt.ManifoldParameter(torch.zeros(out_features, manifold.dim), manifold=manifold.manifold)
 
     def _get_logits_single_manifold(
         self,
@@ -269,9 +262,7 @@ class StereographicLogits(nn.Module):
         bs = M.factorize(b)
         Ws = [w.T for w in M.factorize(W.T)]
         res = [
-            self._get_logits_single_manifold(
-                X_man, W_man, b_man, man, return_inner_products=True
-            )
+            self._get_logits_single_manifold(X_man, W_man, b_man, man, return_inner_products=True)
             for X_man, W_man, b_man, man in zip(Xs, Ws, bs, M.P, strict=False)
         ]
 
@@ -306,13 +297,9 @@ class StereographicLogits(nn.Module):
         """
         # Compute logits based on manifold type
         if isinstance(self.manifold, ProductManifold):
-            logits = self._get_logits_product_manifold(
-                X, self.W, self.p_ks, self.manifold
-            )
+            logits = self._get_logits_product_manifold(X, self.W, self.p_ks, self.manifold)
         else:
-            logits = self._get_logits_single_manifold(
-                X, self.W, self.p_ks, self.manifold, return_inner_products=False
-            )
+            logits = self._get_logits_single_manifold(X, self.W, self.p_ks, self.manifold, return_inner_products=False)
 
         # Optional aggregation via adjacency matrix
         if A_hat is not None and aggregate_logits:
@@ -337,9 +324,7 @@ class FermiDiracDecoder(nn.Module):
             0.0, respectively.
     """
 
-    def __init__(
-        self, manifold: Manifold | ProductManifold, learnable_params: bool = True
-    ):
+    def __init__(self, manifold: Manifold | ProductManifold, learnable_params: bool = True):
         super().__init__()
 
         self.manifold = manifold
@@ -403,9 +388,7 @@ class StereographicLayerNorm(nn.Module):
         self.stereographic_norm = self.manifold.apply(nn.LayerNorm(embedding_dim))
         self.curvatures = curvatures
 
-    def forward(
-        self, X: Float[torch.Tensor, "n_nodes dim"]
-    ) -> Float[torch.Tensor, "n_nodes dim"]:
+    def forward(self, X: Float[torch.Tensor, "n_nodes dim"]) -> Float[torch.Tensor, "n_nodes dim"]:
         """Apply layer normalization on the stereographic manifold."""
         norm_X = self.stereographic_norm(X)
         output = geoopt.manifolds.stereographic.math.project(norm_X, self.curvatures)
@@ -456,16 +439,10 @@ class GeometricLinearizedAttention(nn.Module):
         Returns:
             Output tensor after applying attention.
         """
-        v1 = geoopt.manifolds.stereographic.math.parallel_transport0back(
-            V, Q, k=self.curvatures
-        )
-        v2 = geoopt.manifolds.stereographic.math.parallel_transport0back(
-            V, K, k=self.curvatures
-        )
+        v1 = geoopt.manifolds.stereographic.math.parallel_transport0back(V, Q, k=self.curvatures)
+        v2 = geoopt.manifolds.stereographic.math.parallel_transport0back(V, K, k=self.curvatures)
 
-        gamma = geoopt.manifolds.stereographic.math.lambda_x(
-            x=V, k=self.curvatures, keepdim=True, dim=-1
-        )
+        gamma = geoopt.manifolds.stereographic.math.lambda_x(x=V, k=self.curvatures, keepdim=True, dim=-1)
         denominator = geoopt.utils.clamp_abs((gamma - 1), self._clamp_epsilon)
 
         x = ((gamma / denominator) * V) * mask[None, :, None]
@@ -475,9 +452,7 @@ class GeometricLinearizedAttention(nn.Module):
 
         # Linearized approximation
         v2_cumsum = v2.sum(dim=-2)  # [B, H, D]
-        D = torch.einsum(
-            "...nd,...d->...n", v1, v2_cumsum.type_as(v1)
-        )  # normalization terms
+        D = torch.einsum("...nd,...d->...n", v1, v2_cumsum.type_as(v1))  # normalization terms
         D_inv = 1.0 / D.masked_fill_(D == 0, self._epsilon)
         context = torch.einsum("...nd,...ne->...de", v2, x)
         X = torch.einsum("...de,...nd,...n->...ne", context, v1, D_inv)
@@ -528,16 +503,10 @@ class StereographicAttention(nn.Module):
         self.manifold = manifold
         self.num_heads = num_heads
         self.head_dim = head_dim
-        self.curvatures = _reshape_curvatures(
-            _get_curvatures(self.manifold), self.num_heads
-        )
+        self.curvatures = _reshape_curvatures(_get_curvatures(self.manifold), self.num_heads)
 
-        self.W_q = nn.Linear(
-            in_features=dim, out_features=self.num_heads * self.head_dim
-        )
-        self.W_k = nn.Linear(
-            in_features=dim, out_features=self.num_heads * self.head_dim
-        )
+        self.W_q = nn.Linear(in_features=dim, out_features=self.num_heads * self.head_dim)
+        self.W_k = nn.Linear(in_features=dim, out_features=self.num_heads * self.head_dim)
         self.W_v = KappaGCNLayer(
             in_features=dim,
             out_features=self.num_heads * self.head_dim,
@@ -640,17 +609,11 @@ class StereographicTransformer(nn.Module):
         self.manifold = manifold
         self.curvatures = _reshape_curvatures(_get_curvatures(self.manifold), num_heads)
         self.stereographic_activation = self.manifold.apply(nn.ReLU())
-        self.mha = StereographicAttention(
-            manifold=self.manifold, num_heads=num_heads, dim=dim, head_dim=head_dim
-        )
+        self.mha = StereographicAttention(manifold=self.manifold, num_heads=num_heads, dim=dim, head_dim=head_dim)
 
         if use_layer_norm:
-            self.norm1 = StereographicLayerNorm(
-                manifold=self.manifold, embedding_dim=dim, curvatures=self.curvatures
-            )
-            self.norm2 = StereographicLayerNorm(
-                manifold=self.manifold, embedding_dim=dim, curvatures=self.curvatures
-            )
+            self.norm1 = StereographicLayerNorm(manifold=self.manifold, embedding_dim=dim, curvatures=self.curvatures)
+            self.norm2 = StereographicLayerNorm(manifold=self.manifold, embedding_dim=dim, curvatures=self.curvatures)
         else:
             self.norm1 = nn.Identity()
             self.norm2 = nn.Identity()
@@ -667,21 +630,15 @@ class StereographicTransformer(nn.Module):
         mask: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
     ) -> Float[torch.Tensor, "n_nodes dim"]:
         """Forward pass through the stereographic transformer block."""
-        X = geoopt.manifolds.stereographic.math.mobius_add(
-            self.mha(self.norm1(X), mask), X, self.curvatures
-        )
+        X = geoopt.manifolds.stereographic.math.mobius_add(self.mha(self.norm1(X), mask), X, self.curvatures)
         X = geoopt.manifolds.stereographic.math.project(X, self.curvatures)
-        X = geoopt.manifolds.stereographic.math.mobius_add(
-            self.mlpblock(self.norm2(X)), X, self.curvatures
-        )
+        X = geoopt.manifolds.stereographic.math.mobius_add(self.mlpblock(self.norm2(X)), X, self.curvatures)
         X = geoopt.manifolds.stereographic.math.project(X, self.curvatures)
 
         return X
 
 
-def _reshape_curvatures(
-    curvatures: float | list[float], num_heads: int
-) -> Float[torch.Tensor, "num_heads 1 1"]:
+def _reshape_curvatures(curvatures: float | list[float], num_heads: int) -> Float[torch.Tensor, "num_heads 1 1"]:
     """Helper function to reshape curvature(s) for use in multi-head stereographic attention."""
     if isinstance(curvatures, float):
         output_curvatures = torch.tensor([curvatures] * num_heads, dtype=torch.float)

--- a/manify/predictors/nn/layers.py
+++ b/manify/predictors/nn/layers.py
@@ -31,7 +31,11 @@ class KappaGCNLayer(torch.nn.Module):
     """
 
     def __init__(
-        self, in_features: int, out_features: int, manifold: Manifold, nonlinearity: Callable | None = torch.relu
+        self,
+        in_features: int,
+        out_features: int,
+        manifold: Manifold,
+        nonlinearity: Callable | None = torch.relu,
     ):
         super().__init__()
 
@@ -45,7 +49,10 @@ class KappaGCNLayer(torch.nn.Module):
         self.manifold = manifold
 
     def _left_multiply(
-        self, A: Float[torch.Tensor, "n_nodes n_nodes"], X: Float[torch.Tensor, "n_nodes dim"], M: Manifold
+        self,
+        A: Float[torch.Tensor, "n_nodes n_nodes"],
+        X: Float[torch.Tensor, "n_nodes dim"],
+        M: Manifold,
     ) -> Float[torch.Tensor, "n_nodes dim"]:
         r"""$\kappa$-left matrix multiply two matrices $\mathbf{A}$ and $\mathbf{X}$.
 
@@ -71,7 +78,9 @@ class KappaGCNLayer(torch.nn.Module):
         )
 
     def forward(
-        self, X: Float[torch.Tensor, "n_nodes dim"], A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None
+        self,
+        X: Float[torch.Tensor, "n_nodes dim"],
+        A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
     ) -> Float[torch.Tensor, "n_nodes dim"]:
         """Forward pass for the Kappa GCN layer.
 
@@ -90,7 +99,12 @@ class KappaGCNLayer(torch.nn.Module):
             AXW = XW
         elif isinstance(self.manifold, ProductManifold):
             XWs = self.manifold.factorize(XW)
-            AXW = torch.hstack([self._left_multiply(A_hat, XW, M) for XW, M in zip(XWs, self.manifold.P, strict=False)])
+            AXW = torch.hstack(
+                [
+                    self._left_multiply(A_hat, XW, M)
+                    for XW, M in zip(XWs, self.manifold.P, strict=False)
+                ]
+            )
         else:
             AXW = self._left_multiply(A_hat, XW, self.manifold)
 
@@ -116,7 +130,9 @@ class KappaSequential(nn.Module):
         self.layers = nn.ModuleList(layers)
 
     def forward(
-        self, X: Float[torch.Tensor, "n_nodes dim"], A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None
+        self,
+        X: Float[torch.Tensor, "n_nodes dim"],
+        A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
     ) -> Float[torch.Tensor, "n_nodes out_dim"]:
         """Forward pass through all layers.
 
@@ -167,7 +183,12 @@ class StereographicLogits(nn.Module):
         apply_softmax: Whether to apply softmax to the output logits (default: False)
     """
 
-    def __init__(self, out_features: int, manifold: Manifold | ProductManifold, apply_softmax: bool = False):
+    def __init__(
+        self,
+        out_features: int,
+        manifold: Manifold | ProductManifold,
+        apply_softmax: bool = False,
+    ):
         super().__init__()
 
         self.out_features = out_features
@@ -178,7 +199,9 @@ class StereographicLogits(nn.Module):
         self.W = nn.Parameter(torch.randn(manifold.dim, out_features) * 0.01)
 
         # Bias points on the manifold
-        self.p_ks = geoopt.ManifoldParameter(torch.zeros(out_features, manifold.dim), manifold=manifold.manifold)
+        self.p_ks = geoopt.ManifoldParameter(
+            torch.zeros(out_features, manifold.dim), manifold=manifold.manifold
+        )
 
     def _get_logits_single_manifold(
         self,
@@ -188,7 +211,10 @@ class StereographicLogits(nn.Module):
         M: Manifold,
         return_inner_products: bool = False,
     ) -> (
-        tuple[Float[torch.Tensor, "n_nodes n_classes"], Float[torch.Tensor, "n_nodes n_classes"]]
+        tuple[
+            Float[torch.Tensor, "n_nodes n_classes"],
+            Float[torch.Tensor, "n_nodes n_classes"],
+        ]
         | Float[torch.Tensor, "n_nodes n_classes"]
     ):
         """Compute logits for a single manifold."""
@@ -215,7 +241,9 @@ class StereographicLogits(nn.Module):
         else:
             # Non-Euclidean case: need to do the arsinh
             dist = 2 * za / ((1 + kappa * z_k_norms**2) * a_k_norms)
-            dist = geoopt.manifolds.stereographic.math.arsin_k(dist, kappa * abs(kappa))
+            # arsin_k takes the curvature kappa directly: it scales the argument by
+            # sqrt(|kappa|) internally and multiplies the result by 1/sqrt(|kappa|).
+            dist = geoopt.manifolds.stereographic.math.arsin_k(dist, kappa)
 
             # Get the coefficients
             lambda_pks = M.manifold.lambda_x(b)  # (k,)
@@ -241,7 +269,9 @@ class StereographicLogits(nn.Module):
         bs = M.factorize(b)
         Ws = [w.T for w in M.factorize(W.T)]
         res = [
-            self._get_logits_single_manifold(X_man, W_man, b_man, man, return_inner_products=True)
+            self._get_logits_single_manifold(
+                X_man, W_man, b_man, man, return_inner_products=True
+            )
             for X_man, W_man, b_man, man in zip(Xs, Ws, bs, M.P, strict=False)
         ]
 
@@ -276,9 +306,13 @@ class StereographicLogits(nn.Module):
         """
         # Compute logits based on manifold type
         if isinstance(self.manifold, ProductManifold):
-            logits = self._get_logits_product_manifold(X, self.W, self.p_ks, self.manifold)
+            logits = self._get_logits_product_manifold(
+                X, self.W, self.p_ks, self.manifold
+            )
         else:
-            logits = self._get_logits_single_manifold(X, self.W, self.p_ks, self.manifold, return_inner_products=False)
+            logits = self._get_logits_single_manifold(
+                X, self.W, self.p_ks, self.manifold, return_inner_products=False
+            )
 
         # Optional aggregation via adjacency matrix
         if A_hat is not None and aggregate_logits:
@@ -303,7 +337,9 @@ class FermiDiracDecoder(nn.Module):
             0.0, respectively.
     """
 
-    def __init__(self, manifold: Manifold | ProductManifold, learnable_params: bool = True):
+    def __init__(
+        self, manifold: Manifold | ProductManifold, learnable_params: bool = True
+    ):
         super().__init__()
 
         self.manifold = manifold
@@ -356,7 +392,10 @@ class StereographicLayerNorm(nn.Module):
     """
 
     def __init__(
-        self, manifold: Manifold | ProductManifold, embedding_dim: int, curvatures: torch.Tensor["num_heads 1 1"]
+        self,
+        manifold: Manifold | ProductManifold,
+        embedding_dim: int,
+        curvatures: torch.Tensor["num_heads 1 1"],
     ):
         super().__init__()
 
@@ -364,7 +403,9 @@ class StereographicLayerNorm(nn.Module):
         self.stereographic_norm = self.manifold.apply(nn.LayerNorm(embedding_dim))
         self.curvatures = curvatures
 
-    def forward(self, X: Float[torch.Tensor, "n_nodes dim"]) -> Float[torch.Tensor, "n_nodes dim"]:
+    def forward(
+        self, X: Float[torch.Tensor, "n_nodes dim"]
+    ) -> Float[torch.Tensor, "n_nodes dim"]:
         """Apply layer normalization on the stereographic manifold."""
         norm_X = self.stereographic_norm(X)
         output = geoopt.manifolds.stereographic.math.project(norm_X, self.curvatures)
@@ -415,10 +456,16 @@ class GeometricLinearizedAttention(nn.Module):
         Returns:
             Output tensor after applying attention.
         """
-        v1 = geoopt.manifolds.stereographic.math.parallel_transport0back(V, Q, k=self.curvatures)
-        v2 = geoopt.manifolds.stereographic.math.parallel_transport0back(V, K, k=self.curvatures)
+        v1 = geoopt.manifolds.stereographic.math.parallel_transport0back(
+            V, Q, k=self.curvatures
+        )
+        v2 = geoopt.manifolds.stereographic.math.parallel_transport0back(
+            V, K, k=self.curvatures
+        )
 
-        gamma = geoopt.manifolds.stereographic.math.lambda_x(x=V, k=self.curvatures, keepdim=True, dim=-1)
+        gamma = geoopt.manifolds.stereographic.math.lambda_x(
+            x=V, k=self.curvatures, keepdim=True, dim=-1
+        )
         denominator = geoopt.utils.clamp_abs((gamma - 1), self._clamp_epsilon)
 
         x = ((gamma / denominator) * V) * mask[None, :, None]
@@ -428,14 +475,19 @@ class GeometricLinearizedAttention(nn.Module):
 
         # Linearized approximation
         v2_cumsum = v2.sum(dim=-2)  # [B, H, D]
-        D = torch.einsum("...nd,...d->...n", v1, v2_cumsum.type_as(v1))  # normalization terms
+        D = torch.einsum(
+            "...nd,...d->...n", v1, v2_cumsum.type_as(v1)
+        )  # normalization terms
         D_inv = 1.0 / D.masked_fill_(D == 0, self._epsilon)
         context = torch.einsum("...nd,...ne->...de", v2, x)
         X = torch.einsum("...de,...nd,...n->...ne", context, v1, D_inv)
 
         X = geoopt.manifolds.stereographic.math.project(X, k=self.curvatures)
         X = geoopt.manifolds.stereographic.math.mobius_scalar_mul(
-            torch.tensor(0.5, dtype=X.dtype, device=X.device), X, k=self.curvatures, dim=-1
+            torch.tensor(0.5, dtype=X.dtype, device=X.device),
+            X,
+            k=self.curvatures,
+            dim=-1,
         )
         X = geoopt.manifolds.stereographic.math.project(X, k=self.curvatures)
 
@@ -464,22 +516,42 @@ class StereographicAttention(nn.Module):
         ff: Manifold-aware linear layer for the feedforward output.
     """
 
-    def __init__(self, manifold: Manifold | ProductManifold, num_heads: int, dim: int, head_dim: int):
+    def __init__(
+        self,
+        manifold: Manifold | ProductManifold,
+        num_heads: int,
+        dim: int,
+        head_dim: int,
+    ):
         super().__init__()
 
         self.manifold = manifold
         self.num_heads = num_heads
         self.head_dim = head_dim
-        self.curvatures = _reshape_curvatures(_get_curvatures(self.manifold), self.num_heads)
+        self.curvatures = _reshape_curvatures(
+            _get_curvatures(self.manifold), self.num_heads
+        )
 
-        self.W_q = nn.Linear(in_features=dim, out_features=self.num_heads * self.head_dim)
-        self.W_k = nn.Linear(in_features=dim, out_features=self.num_heads * self.head_dim)
-        self.W_v = KappaGCNLayer(in_features=dim, out_features=self.num_heads * self.head_dim, manifold=self.manifold)
+        self.W_q = nn.Linear(
+            in_features=dim, out_features=self.num_heads * self.head_dim
+        )
+        self.W_k = nn.Linear(
+            in_features=dim, out_features=self.num_heads * self.head_dim
+        )
+        self.W_v = KappaGCNLayer(
+            in_features=dim,
+            out_features=self.num_heads * self.head_dim,
+            manifold=self.manifold,
+        )
 
         self.attn = GeometricLinearizedAttention(
             curvatures=self.curvatures, num_heads=self.num_heads, head_dim=self.head_dim
         )
-        self.ff = KappaGCNLayer(in_features=self.num_heads * self.head_dim, out_features=dim, manifold=self.manifold)
+        self.ff = KappaGCNLayer(
+            in_features=self.num_heads * self.head_dim,
+            out_features=dim,
+            manifold=self.manifold,
+        )
 
     def forward(
         self,
@@ -550,7 +622,12 @@ class StereographicTransformer(nn.Module):
     """
 
     def __init__(
-        self, manifold: Manifold | ProductManifold, num_heads: int, dim: int, head_dim: int, use_layer_norm: bool = True
+        self,
+        manifold: Manifold | ProductManifold,
+        num_heads: int,
+        dim: int,
+        head_dim: int,
+        use_layer_norm: bool = True,
     ):
         super().__init__()
 
@@ -563,11 +640,17 @@ class StereographicTransformer(nn.Module):
         self.manifold = manifold
         self.curvatures = _reshape_curvatures(_get_curvatures(self.manifold), num_heads)
         self.stereographic_activation = self.manifold.apply(nn.ReLU())
-        self.mha = StereographicAttention(manifold=self.manifold, num_heads=num_heads, dim=dim, head_dim=head_dim)
+        self.mha = StereographicAttention(
+            manifold=self.manifold, num_heads=num_heads, dim=dim, head_dim=head_dim
+        )
 
         if use_layer_norm:
-            self.norm1 = StereographicLayerNorm(manifold=self.manifold, embedding_dim=dim, curvatures=self.curvatures)
-            self.norm2 = StereographicLayerNorm(manifold=self.manifold, embedding_dim=dim, curvatures=self.curvatures)
+            self.norm1 = StereographicLayerNorm(
+                manifold=self.manifold, embedding_dim=dim, curvatures=self.curvatures
+            )
+            self.norm2 = StereographicLayerNorm(
+                manifold=self.manifold, embedding_dim=dim, curvatures=self.curvatures
+            )
         else:
             self.norm1 = nn.Identity()
             self.norm2 = nn.Identity()
@@ -584,15 +667,21 @@ class StereographicTransformer(nn.Module):
         mask: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
     ) -> Float[torch.Tensor, "n_nodes dim"]:
         """Forward pass through the stereographic transformer block."""
-        X = geoopt.manifolds.stereographic.math.mobius_add(self.mha(self.norm1(X), mask), X, self.curvatures)
+        X = geoopt.manifolds.stereographic.math.mobius_add(
+            self.mha(self.norm1(X), mask), X, self.curvatures
+        )
         X = geoopt.manifolds.stereographic.math.project(X, self.curvatures)
-        X = geoopt.manifolds.stereographic.math.mobius_add(self.mlpblock(self.norm2(X)), X, self.curvatures)
+        X = geoopt.manifolds.stereographic.math.mobius_add(
+            self.mlpblock(self.norm2(X)), X, self.curvatures
+        )
         X = geoopt.manifolds.stereographic.math.project(X, self.curvatures)
 
         return X
 
 
-def _reshape_curvatures(curvatures: float | list[float], num_heads: int) -> Float[torch.Tensor, "num_heads 1 1"]:
+def _reshape_curvatures(
+    curvatures: float | list[float], num_heads: int
+) -> Float[torch.Tensor, "num_heads 1 1"]:
     """Helper function to reshape curvature(s) for use in multi-head stereographic attention."""
     if isinstance(curvatures, float):
         output_curvatures = torch.tensor([curvatures] * num_heads, dtype=torch.float)

--- a/manify/predictors/svm.py
+++ b/manify/predictors/svm.py
@@ -81,8 +81,12 @@ class ProductSpaceSVM(BasePredictor):
         self.e_constraints = e_constraints
         self.eps = epsilon
         self.task = task
-        self.weights = torch.ones(len(pm.P), dtype=torch.float32) if weights is None else weights
-        assert len(self.weights) == len(pm.P), "Number of weights must match the number of manifolds."
+        self.weights = (
+            torch.ones(len(pm.P), dtype=torch.float32) if weights is None else weights
+        )
+        assert len(self.weights) == len(
+            pm.P
+        ), "Number of weights must match the number of manifolds."
 
     def fit(
         self,
@@ -153,8 +157,14 @@ class ProductSpaceSVM(BasePredictor):
                     eigvals, eigvecs = np.linalg.eigh(P_np)
                     plus = np.clip(eigvals, 0, None)
                     minus = np.clip(-eigvals, 0, None)
-                    Kp = (eigvecs @ np.diag(plus) @ eigvecs.T + (eigvecs @ np.diag(plus) @ eigvecs.T).T) * 0.5
-                    Km = (eigvecs @ np.diag(minus) @ eigvecs.T + (eigvecs @ np.diag(minus) @ eigvecs.T).T) * 0.5
+                    Kp = (
+                        eigvecs @ np.diag(plus) @ eigvecs.T
+                        + (eigvecs @ np.diag(plus) @ eigvecs.T).T
+                    ) * 0.5
+                    Km = (
+                        eigvecs @ np.diag(minus) @ eigvecs.T
+                        + (eigvecs @ np.diag(minus) @ eigvecs.T).T
+                    ) * 0.5
                     Bp = sqrtm_psd(Kp)
                     Bm = sqrtm_psd(Km)
 
@@ -163,18 +173,24 @@ class ProductSpaceSVM(BasePredictor):
                     r_h = abs(np.arcsinh(-(R**2) * C_H))
                     r = self.eps
 
-                    constraints.append(cp.norm(Bm @ beta_var, 2) <= np.sqrt(max(r, 0.0)))
-                    constraints.append(cp.norm(Bp @ beta_var, 2) <= np.sqrt(max(r + r_h, 0.0)))
+                    constraints.append(
+                        cp.norm(Bm @ beta_var, 2) <= np.sqrt(max(r, 0.0))
+                    )
+                    constraints.append(
+                        cp.norm(Bp @ beta_var, 2) <= np.sqrt(max(r + r_h, 0.0))
+                    )
 
             # solve
             prob = cp.Problem(cp.Minimize(-eps_var + cp.sum(zeta)), constraints)
             prob.solve(solver="SCS")
 
-            # save results
+            # save results. eps_var and b_var are length-1 cp.Variables, so their
+            # .value is a 1-element ndarray; index it before float() (numpy 2.x no
+            # longer coerces 1-element arrays to scalars implicitly).
             self.beta[cls_item] = np.ravel(beta_var.value)
             self.zeta[cls_item] = zeta.value
-            self.epsilon[cls_item] = float(eps_var.value)
-            self.b[cls_item] = float(b_var.value)
+            self.epsilon[cls_item] = float(np.ravel(eps_var.value)[0])
+            self.b[cls_item] = float(np.ravel(b_var.value)[0])
 
         # store training data
         self.X_train_ = torch.tensor(X_np, dtype=torch.float32)
@@ -193,11 +209,17 @@ class ProductSpaceSVM(BasePredictor):
         Returns:
             class_probabilities: Class probabilities for each test sample.
         """
-        X_tensor = torch.tensor(X, dtype=torch.float32) if not isinstance(X, torch.Tensor) else X
+        X_tensor = (
+            torch.tensor(X, dtype=torch.float32)
+            if not isinstance(X, torch.Tensor)
+            else X
+        )
         X_tensor = X_tensor.to(self.X_train_.device)
 
         Ks_test, _ = product_kernel(self.pm, self.X_train_, X_tensor)
-        Kt = torch.ones((self.X_train_.shape[0], X_tensor.shape[0]), device=X_tensor.device)
+        Kt = torch.ones(
+            (self.X_train_.shape[0], X_tensor.shape[0]), device=X_tensor.device
+        )
         for K_m, w in zip(Ks_test, self.weights, strict=False):
             Kt += w * K_m
         Kt_np = Kt.detach().cpu().numpy()

--- a/manify/predictors/svm.py
+++ b/manify/predictors/svm.py
@@ -81,12 +81,8 @@ class ProductSpaceSVM(BasePredictor):
         self.e_constraints = e_constraints
         self.eps = epsilon
         self.task = task
-        self.weights = (
-            torch.ones(len(pm.P), dtype=torch.float32) if weights is None else weights
-        )
-        assert len(self.weights) == len(
-            pm.P
-        ), "Number of weights must match the number of manifolds."
+        self.weights = torch.ones(len(pm.P), dtype=torch.float32) if weights is None else weights
+        assert len(self.weights) == len(pm.P), "Number of weights must match the number of manifolds."
 
     def fit(
         self,
@@ -157,14 +153,8 @@ class ProductSpaceSVM(BasePredictor):
                     eigvals, eigvecs = np.linalg.eigh(P_np)
                     plus = np.clip(eigvals, 0, None)
                     minus = np.clip(-eigvals, 0, None)
-                    Kp = (
-                        eigvecs @ np.diag(plus) @ eigvecs.T
-                        + (eigvecs @ np.diag(plus) @ eigvecs.T).T
-                    ) * 0.5
-                    Km = (
-                        eigvecs @ np.diag(minus) @ eigvecs.T
-                        + (eigvecs @ np.diag(minus) @ eigvecs.T).T
-                    ) * 0.5
+                    Kp = (eigvecs @ np.diag(plus) @ eigvecs.T + (eigvecs @ np.diag(plus) @ eigvecs.T).T) * 0.5
+                    Km = (eigvecs @ np.diag(minus) @ eigvecs.T + (eigvecs @ np.diag(minus) @ eigvecs.T).T) * 0.5
                     Bp = sqrtm_psd(Kp)
                     Bm = sqrtm_psd(Km)
 
@@ -173,12 +163,8 @@ class ProductSpaceSVM(BasePredictor):
                     r_h = abs(np.arcsinh(-(R**2) * C_H))
                     r = self.eps
 
-                    constraints.append(
-                        cp.norm(Bm @ beta_var, 2) <= np.sqrt(max(r, 0.0))
-                    )
-                    constraints.append(
-                        cp.norm(Bp @ beta_var, 2) <= np.sqrt(max(r + r_h, 0.0))
-                    )
+                    constraints.append(cp.norm(Bm @ beta_var, 2) <= np.sqrt(max(r, 0.0)))
+                    constraints.append(cp.norm(Bp @ beta_var, 2) <= np.sqrt(max(r + r_h, 0.0)))
 
             # solve
             prob = cp.Problem(cp.Minimize(-eps_var + cp.sum(zeta)), constraints)
@@ -209,17 +195,11 @@ class ProductSpaceSVM(BasePredictor):
         Returns:
             class_probabilities: Class probabilities for each test sample.
         """
-        X_tensor = (
-            torch.tensor(X, dtype=torch.float32)
-            if not isinstance(X, torch.Tensor)
-            else X
-        )
+        X_tensor = torch.tensor(X, dtype=torch.float32) if not isinstance(X, torch.Tensor) else X
         X_tensor = X_tensor.to(self.X_train_.device)
 
         Ks_test, _ = product_kernel(self.pm, self.X_train_, X_tensor)
-        Kt = torch.ones(
-            (self.X_train_.shape[0], X_tensor.shape[0]), device=X_tensor.device
-        )
+        Kt = torch.ones((self.X_train_.shape[0], X_tensor.shape[0]), device=X_tensor.device)
         for K_m, w in zip(Ks_test, self.weights, strict=False):
             Kt += w * K_m
         Kt_np = Kt.detach().cpu().numpy()

--- a/manify/utils/benchmarks.py
+++ b/manify/utils/benchmarks.py
@@ -36,9 +36,7 @@ if TYPE_CHECKING:
         "kappa_mlr",
         "single_manifold_rf",
     ]
-    SCORETYPE: TypeAlias = Literal[
-        "accuracy", "f1-micro", "f1-macro", "mse", "percent_rmse", "time"
-    ]
+    SCORETYPE: TypeAlias = Literal["accuracy", "f1-micro", "f1-macro", "mse", "percent_rmse", "time"]
     TASKTYPE: TypeAlias = Literal["classification", "regression", "link_prediction"]
 
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
@@ -70,9 +68,7 @@ def _score(
 ) -> dict[SCORETYPE, float]:
     """Helper function to score a model."""
     score = score or ["accuracy", "f1-micro"]
-    assert (
-        model is not None or y_pred_override is not None
-    ), "Model must be provided if y_pred_override is not given"
+    assert model is not None or y_pred_override is not None, "Model must be provided if y_pred_override is not given"
     y_pred = y_pred_override if y_pred_override is not None else model.predict(_X)  # type: ignore
 
     if use_torch:
@@ -84,13 +80,9 @@ def _score(
         "f1-macro": lambda y, p: f1_score(y, p, average="macro"),
         "mse": mean_squared_error,
         "rmse": root_mean_squared_error,
-        "percent_rmse": lambda y, p: (
-            root_mean_squared_error(y, p, multioutput="raw_values") / np.abs(y)
-        ).mean(),
+        "percent_rmse": lambda y, p: (root_mean_squared_error(y, p, multioutput="raw_values") / np.abs(y)).mean(),
     }
-    return {
-        s: scoring_funcs[s](_y, y_pred) if s in scoring_funcs else np.nan for s in score
-    }
+    return {s: scoring_funcs[s](_y, y_pred) if s in scoring_funcs else np.nan for s in score}
 
 
 def benchmark(
@@ -178,11 +170,7 @@ def benchmark(
     """
     # Task-appropriate default scores (regression cannot use accuracy/f1).
     if score is None:
-        score = (
-            ["mse", "rmse"]
-            if task == "regression"
-            else ["accuracy", "f1-micro", "f1-macro"]
-        )
+        score = ["mse", "rmse"] if task == "regression" else ["accuracy", "f1-micro", "f1-macro"]
     models = models or [
         "sklearn_dt",
         "sklearn_rf",
@@ -217,12 +205,7 @@ def benchmark(
     pm = pm.to(device)
 
     # Split data
-    if (
-        X_train is not None
-        and X_test is not None
-        and y_train is not None
-        and y_test is not None
-    ):
+    if X_train is not None and X_test is not None and y_train is not None and y_test is not None:
         # Coerce to tensor as needed
         if not torch.is_tensor(X_train):
             X_train = torch.tensor(X_train)
@@ -255,9 +238,7 @@ def benchmark(
         X = X.to(device)
         y = y.to(device)
 
-        X_train, X_test, y_train, y_test, train_idx, test_idx = train_test_split(
-            X, y, np.arange(len(X)), test_size=0.2
-        )
+        X_train, X_test, y_train, y_test, train_idx, test_idx = train_test_split(X, y, np.arange(len(X)), test_size=0.2)
 
     # Make sure classification labels are formatted correctly
     if task in {"classification", "link_prediction"}:
@@ -298,9 +279,7 @@ def benchmark(
     X_test_stereo = X_test_stereo.detach()
 
     # Also euclidean """PM"""
-    pm_euc = ProductManifold(
-        signature=[(0.0, X.shape[1])], device=device, stereographic=True
-    )
+    pm_euc = ProductManifold(signature=[(0.0, X.shape[1])], device=device, stereographic=True)
 
     # Get A_hat
     if adj is not None:
@@ -357,9 +336,7 @@ def benchmark(
         t1 = time.time()
         dt.fit(X_train_np, y_train_np)
         t2 = time.time()
-        accs["sklearn_dt"] = _score(
-            X_test_np, y_test_np, dt, use_torch=False, score=score
-        )
+        accs["sklearn_dt"] = _score(X_test_np, y_test_np, dt, use_torch=False, score=score)
         accs["sklearn_dt"]["time"] = t2 - t1
 
     if "sklearn_rf" in models:
@@ -367,9 +344,7 @@ def benchmark(
         t1 = time.time()
         rf.fit(X_train_np, y_train_np)
         t2 = time.time()
-        accs["sklearn_rf"] = _score(
-            X_test_np, y_test_np, rf, use_torch=False, score=score
-        )
+        accs["sklearn_rf"] = _score(X_test_np, y_test_np, rf, use_torch=False, score=score)
         accs["sklearn_rf"]["time"] = t2 - t1
 
     if "product_dt" in models:
@@ -377,9 +352,7 @@ def benchmark(
         t1 = time.time()
         psdt.fit(X_train, y_train)
         t2 = time.time()
-        accs["product_dt"] = _score(
-            X_test, y_test_np, psdt, use_torch=True, score=score
-        )
+        accs["product_dt"] = _score(X_test, y_test_np, psdt, use_torch=True, score=score)
         accs["product_dt"]["time"] = t2 - t1
 
     if "product_rf" in models:
@@ -387,9 +360,7 @@ def benchmark(
         t1 = time.time()
         psrf.fit(X_train, y_train)
         t2 = time.time()
-        accs["product_rf"] = _score(
-            X_test, y_test_np, psrf, use_torch=True, score=score
-        )
+        accs["product_rf"] = _score(X_test, y_test_np, psrf, use_torch=True, score=score)
         accs["product_rf"]["time"] = t2 - t1
 
     # if "single_manifold_rf" in models:
@@ -405,9 +376,7 @@ def benchmark(
         t1 = time.time()
         tdt.fit(X_train_tangent_np, y_train_np)
         t2 = time.time()
-        accs["tangent_dt"] = _score(
-            X_test_tangent_np, y_test_np, tdt, use_torch=False, score=score
-        )
+        accs["tangent_dt"] = _score(X_test_tangent_np, y_test_np, tdt, use_torch=False, score=score)
         accs["tangent_dt"]["time"] = t2 - t1
 
     if "tangent_rf" in models:
@@ -415,18 +384,14 @@ def benchmark(
         t1 = time.time()
         trf.fit(X_train_tangent_np, y_train_np)
         t2 = time.time()
-        accs["tangent_rf"] = _score(
-            X_test_tangent_np, y_test_np, trf, use_torch=False, score=score
-        )
+        accs["tangent_rf"] = _score(X_test_tangent_np, y_test_np, trf, use_torch=False, score=score)
         accs["tangent_rf"]["time"] = t2 - t1
 
     if "knn" in models:
         # Get dists - max imputation is a workaround for some nan values we occasionally get
         t1 = time.time()
         train_dists = pm.pdist(X_train)
-        train_dists = torch.nan_to_num(
-            train_dists, nan=train_dists[~train_dists.isnan()].max().item()
-        )
+        train_dists = torch.nan_to_num(train_dists, nan=train_dists[~train_dists.isnan()].max().item())
         train_test_dists = pm.dist(X_test, X_train)
         train_test_dists = torch.nan_to_num(
             train_test_dists,
@@ -442,9 +407,7 @@ def benchmark(
         t2 = time.time()
         knn.fit(train_dists, y_train_np)
         t3 = time.time()
-        accs["knn"] = _score(
-            train_test_dists, y_test_np, knn, use_torch=False, score=score
-        )
+        accs["knn"] = _score(train_test_dists, y_test_np, knn, use_torch=False, score=score)
         accs["knn"]["time"] = t3 - t1
 
     # if "perceptron" in models:
@@ -468,9 +431,7 @@ def benchmark(
             t1 = time.time()
             ps_per.fit(X_train, y_train)
             t2 = time.time()
-            accs["ps_perceptron"] = _score(
-                X_test, y_test_np, ps_per, use_torch=True, score=score
-            )
+            accs["ps_perceptron"] = _score(X_test, y_test_np, ps_per, use_torch=True, score=score)
             accs["ps_perceptron"]["time"] = t2 - t1
         else:
             warnings.warn(
@@ -481,12 +442,8 @@ def benchmark(
     if "svm" in models:
         # Get inner products for precomputed kernel matrix
         t1 = time.time()
-        train_ips = pm.manifold.component_inner(X_train[:, None], X_train[None, :]).sum(
-            dim=-1
-        )
-        train_test_ips = pm.manifold.component_inner(
-            X_test[:, None], X_train[None, :]
-        ).sum(dim=-1)
+        train_ips = pm.manifold.component_inner(X_train[:, None], X_train[None, :]).sum(dim=-1)
+        train_test_ips = pm.manifold.component_inner(X_test[:, None], X_train[None, :]).sum(dim=-1)
 
         # Convert to numpy
         train_ips = train_ips.detach().cpu().numpy()
@@ -498,9 +455,7 @@ def benchmark(
         t2 = time.time()
         svm.fit(train_ips, y_train_np)
         t3 = time.time()
-        accs["svm"] = _score(
-            train_test_ips, y_test_np, svm, use_torch=False, score=score
-        )
+        accs["svm"] = _score(train_test_ips, y_test_np, svm, use_torch=False, score=score)
         accs["svm"]["time"] = t3 - t1
 
     if "ps_svm" in models:
@@ -551,9 +506,7 @@ def benchmark(
     if "ambient_mlp" in models:
         ambient_mlp = KappaGCN(pm=pm_euc, num_hidden=kappa_gcn_layers, **nn_kwargs).to(device)  # type: ignore
         t1 = time.time()
-        ambient_mlp.fit(
-            X_train, y_train, A=None, tqdm_prefix="ambient_mlp", **nn_train_kwargs
-        )
+        ambient_mlp.fit(X_train, y_train, A=None, tqdm_prefix="ambient_mlp", **nn_train_kwargs)
         t2 = time.time()
         y_pred = ambient_mlp.predict(X_test, A=None)
         accs["ambient_mlp"] = _score(
@@ -594,9 +547,7 @@ def benchmark(
         ambient_gcn.fit(X_train, y_train, A=A_train, **nn_train_kwargs)
         t2 = time.time()
         y_pred = ambient_gcn.predict(X_test, A=A_test)
-        accs["ambient_gcn"] = _score(
-            None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score
-        )
+        accs["ambient_gcn"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
         accs["ambient_gcn"]["time"] = t2 - t1
 
     if "tangent_gcn" in models:
@@ -611,9 +562,7 @@ def benchmark(
         )
         t2 = time.time()
         y_pred = tangent_gcn.predict(X_test_tangent, A=A_test)
-        accs["tangent_gcn"] = _score(
-            None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score
-        )
+        accs["tangent_gcn"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
         accs["tangent_gcn"]["time"] = t2 - t1
 
     if "kappa_gcn" in models:
@@ -629,22 +578,16 @@ def benchmark(
         )
         t2 = time.time()
         y_pred = kappa_gcn.predict(X_test_stereo, A=A_test)
-        accs["kappa_gcn"] = _score(
-            None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score
-        )
+        accs["kappa_gcn"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
         accs["kappa_gcn"]["time"] = t2 - t1
 
     if "kappa_mlr" in models:
         kappa_mlr = KappaGCN(pm=pm_stereo, num_hidden=0, task=task, output_dim=nn_outdim).to(device)  # type: ignore
         t1 = time.time()
-        kappa_mlr.fit(
-            X_train_stereo, y_train, A=None, tqdm_prefix="kappa_mlr", **nn_train_kwargs
-        )
+        kappa_mlr.fit(X_train_stereo, y_train, A=None, tqdm_prefix="kappa_mlr", **nn_train_kwargs)
         t2 = time.time()
         y_pred = kappa_mlr.predict(X_test_stereo, A=None)
-        accs["kappa_mlr"] = _score(
-            None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score
-        )
+        accs["kappa_mlr"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
         accs["kappa_mlr"]["time"] = t2 - t1
 
     if "tangent_mlr" in models:
@@ -659,22 +602,16 @@ def benchmark(
         )
         t2 = time.time()
         y_pred = tangent_mlr.predict(X_test_tangent, A=None)
-        accs["tangent_mlr"] = _score(
-            None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score
-        )
+        accs["tangent_mlr"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
         accs["tangent_mlr"]["time"] = t2 - t1
 
     if "ambient_mlr" in models:
         ambient_mlr = KappaGCN(pm=pm_euc, num_hidden=0, task=task, output_dim=nn_outdim).to(device)  # type: ignore
         t1 = time.time()
-        ambient_mlr.fit(
-            X_train, y_train, A=None, tqdm_prefix="ambient_mlr", **nn_train_kwargs
-        )
+        ambient_mlr.fit(X_train, y_train, A=None, tqdm_prefix="ambient_mlr", **nn_train_kwargs)
         t2 = time.time()
         y_pred = ambient_mlr.predict(X_test, A=None)
-        accs["ambient_mlr"] = _score(
-            None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score
-        )
+        accs["ambient_mlr"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
         accs["ambient_mlr"]["time"] = t2 - t1
 
     # return accs

--- a/manify/utils/benchmarks.py
+++ b/manify/utils/benchmarks.py
@@ -36,11 +36,18 @@ if TYPE_CHECKING:
         "kappa_mlr",
         "single_manifold_rf",
     ]
-    SCORETYPE: TypeAlias = Literal["accuracy", "f1-micro", "f1-macro", "mse", "percent_rmse", "time"]
+    SCORETYPE: TypeAlias = Literal[
+        "accuracy", "f1-micro", "f1-macro", "mse", "percent_rmse", "time"
+    ]
     TASKTYPE: TypeAlias = Literal["classification", "regression", "link_prediction"]
 
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
-from sklearn.metrics import accuracy_score, f1_score, mean_squared_error, root_mean_squared_error
+from sklearn.metrics import (
+    accuracy_score,
+    f1_score,
+    mean_squared_error,
+    root_mean_squared_error,
+)
 from sklearn.model_selection import train_test_split
 from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 from sklearn.svm import SVC, SVR
@@ -63,7 +70,9 @@ def _score(
 ) -> dict[SCORETYPE, float]:
     """Helper function to score a model."""
     score = score or ["accuracy", "f1-micro"]
-    assert model is not None or y_pred_override is not None, "Model must be provided if y_pred_override is not given"
+    assert (
+        model is not None or y_pred_override is not None
+    ), "Model must be provided if y_pred_override is not given"
     y_pred = y_pred_override if y_pred_override is not None else model.predict(_X)  # type: ignore
 
     if use_torch:
@@ -75,9 +84,13 @@ def _score(
         "f1-macro": lambda y, p: f1_score(y, p, average="macro"),
         "mse": mean_squared_error,
         "rmse": root_mean_squared_error,
-        "percent_rmse": lambda y, p: (root_mean_squared_error(y, p, multioutput="raw_values") / np.abs(y)).mean(),
+        "percent_rmse": lambda y, p: (
+            root_mean_squared_error(y, p, multioutput="raw_values") / np.abs(y)
+        ).mean(),
     }
-    return {s: scoring_funcs[s](_y, y_pred) if s in scoring_funcs else np.nan for s in score}
+    return {
+        s: scoring_funcs[s](_y, y_pred) if s in scoring_funcs else np.nan for s in score
+    }
 
 
 def benchmark(
@@ -163,7 +176,13 @@ def benchmark(
     Returns:
         Dictionary mapping model names to their corresponding evaluation scores.
     """
-    score = score or ["accuracy", "f1-micro", "f1-macro"]
+    # Task-appropriate default scores (regression cannot use accuracy/f1).
+    if score is None:
+        score = (
+            ["mse", "rmse"]
+            if task == "regression"
+            else ["accuracy", "f1-micro", "f1-macro"]
+        )
     models = models or [
         "sklearn_dt",
         "sklearn_rf",
@@ -191,12 +210,6 @@ def benchmark(
         assert all(s in {"accuracy", "f1-micro", "f1-macro", "time"} for s in score)
     elif task == "regression":
         assert all(s in {"mse", "rmse", "percent_rmse", "time"} for s in score)
-
-    # Input validation on (task, score) pairing
-    if task in {"classification", "link_prediction"}:
-        assert all(s in {"accuracy", "f1-micro", "f1-macro", "time"} for s in score)
-    elif task == "regression":
-        assert all(s in {"mse", "rmse", "percent_rmse", "time"} for s in score)
     else:
         raise ValueError(f"Unknown task: {task}")
 
@@ -204,7 +217,12 @@ def benchmark(
     pm = pm.to(device)
 
     # Split data
-    if X_train is not None and X_test is not None and y_train is not None and y_test is not None:
+    if (
+        X_train is not None
+        and X_test is not None
+        and y_train is not None
+        and y_test is not None
+    ):
         # Coerce to tensor as needed
         if not torch.is_tensor(X_train):
             X_train = torch.tensor(X_train)
@@ -237,7 +255,9 @@ def benchmark(
         X = X.to(device)
         y = y.to(device)
 
-        X_train, X_test, y_train, y_test, train_idx, test_idx = train_test_split(X, y, np.arange(len(X)), test_size=0.2)
+        X_train, X_test, y_train, y_test, train_idx, test_idx = train_test_split(
+            X, y, np.arange(len(X)), test_size=0.2
+        )
 
     # Make sure classification labels are formatted correctly
     if task in {"classification", "link_prediction"}:
@@ -257,9 +277,18 @@ def benchmark(
     X_test_tangent = pm.logmap(X_test).detach()
 
     # Get numpy versions
-    X_train_np, X_test_np = X_train.detach().cpu().numpy(), X_test.detach().cpu().numpy()
-    y_train_np, y_test_np = y_train.detach().cpu().numpy(), y_test.detach().cpu().numpy()
-    X_train_tangent_np, X_test_tangent_np = X_train_tangent.cpu().numpy(), X_test_tangent.cpu().numpy()
+    X_train_np, X_test_np = (
+        X_train.detach().cpu().numpy(),
+        X_test.detach().cpu().numpy(),
+    )
+    y_train_np, y_test_np = (
+        y_train.detach().cpu().numpy(),
+        y_test.detach().cpu().numpy(),
+    )
+    X_train_tangent_np, X_test_tangent_np = (
+        X_train_tangent.cpu().numpy(),
+        X_test_tangent.cpu().numpy(),
+    )
 
     # Get stereographic version
     pm_stereo, X_train_stereo, X_test_stereo = pm.stereographic(X_train, X_test)
@@ -269,7 +298,9 @@ def benchmark(
     X_test_stereo = X_test_stereo.detach()
 
     # Also euclidean """PM"""
-    pm_euc = ProductManifold(signature=[(0.0, X.shape[1])], device=device, stereographic=True)
+    pm_euc = ProductManifold(
+        signature=[(0.0, X.shape[1])], device=device, stereographic=True
+    )
 
     # Get A_hat
     if adj is not None:
@@ -291,8 +322,16 @@ def benchmark(
         A_test = A_test.to(device).detach()
 
     # Aggregate arguments
-    tree_kwargs = {"max_depth": max_depth, "min_samples_leaf": min_samples_leaf, "min_samples_split": min_samples_split}
-    prod_kwargs = {"use_special_dims": use_special_dims, "n_features": n_features, "batch_size": batch_size}
+    tree_kwargs = {
+        "max_depth": max_depth,
+        "min_samples_leaf": min_samples_leaf,
+        "min_samples_split": min_samples_split,
+    }
+    prod_kwargs = {
+        "use_special_dims": use_special_dims,
+        "n_features": n_features,
+        "batch_size": batch_size,
+    }
     rf_kwargs = {"n_estimators": n_estimators, "n_jobs": -1, "random_state": seed}
     nn_outdim = 1 if task == "regression" else len(torch.unique(y))
     nn_kwargs = {"task": task, "output_dim": nn_outdim}
@@ -318,7 +357,9 @@ def benchmark(
         t1 = time.time()
         dt.fit(X_train_np, y_train_np)
         t2 = time.time()
-        accs["sklearn_dt"] = _score(X_test_np, y_test_np, dt, use_torch=False, score=score)
+        accs["sklearn_dt"] = _score(
+            X_test_np, y_test_np, dt, use_torch=False, score=score
+        )
         accs["sklearn_dt"]["time"] = t2 - t1
 
     if "sklearn_rf" in models:
@@ -326,7 +367,9 @@ def benchmark(
         t1 = time.time()
         rf.fit(X_train_np, y_train_np)
         t2 = time.time()
-        accs["sklearn_rf"] = _score(X_test_np, y_test_np, rf, use_torch=False, score=score)
+        accs["sklearn_rf"] = _score(
+            X_test_np, y_test_np, rf, use_torch=False, score=score
+        )
         accs["sklearn_rf"]["time"] = t2 - t1
 
     if "product_dt" in models:
@@ -334,7 +377,9 @@ def benchmark(
         t1 = time.time()
         psdt.fit(X_train, y_train)
         t2 = time.time()
-        accs["product_dt"] = _score(X_test, y_test_np, psdt, use_torch=True, score=score)
+        accs["product_dt"] = _score(
+            X_test, y_test_np, psdt, use_torch=True, score=score
+        )
         accs["product_dt"]["time"] = t2 - t1
 
     if "product_rf" in models:
@@ -342,7 +387,9 @@ def benchmark(
         t1 = time.time()
         psrf.fit(X_train, y_train)
         t2 = time.time()
-        accs["product_rf"] = _score(X_test, y_test_np, psrf, use_torch=True, score=score)
+        accs["product_rf"] = _score(
+            X_test, y_test_np, psrf, use_torch=True, score=score
+        )
         accs["product_rf"]["time"] = t2 - t1
 
     # if "single_manifold_rf" in models:
@@ -358,7 +405,9 @@ def benchmark(
         t1 = time.time()
         tdt.fit(X_train_tangent_np, y_train_np)
         t2 = time.time()
-        accs["tangent_dt"] = _score(X_test_tangent_np, y_test_np, tdt, use_torch=False, score=score)
+        accs["tangent_dt"] = _score(
+            X_test_tangent_np, y_test_np, tdt, use_torch=False, score=score
+        )
         accs["tangent_dt"]["time"] = t2 - t1
 
     if "tangent_rf" in models:
@@ -366,14 +415,18 @@ def benchmark(
         t1 = time.time()
         trf.fit(X_train_tangent_np, y_train_np)
         t2 = time.time()
-        accs["tangent_rf"] = _score(X_test_tangent_np, y_test_np, trf, use_torch=False, score=score)
+        accs["tangent_rf"] = _score(
+            X_test_tangent_np, y_test_np, trf, use_torch=False, score=score
+        )
         accs["tangent_rf"]["time"] = t2 - t1
 
     if "knn" in models:
         # Get dists - max imputation is a workaround for some nan values we occasionally get
         t1 = time.time()
         train_dists = pm.pdist(X_train)
-        train_dists = torch.nan_to_num(train_dists, nan=train_dists[~train_dists.isnan()].max().item())
+        train_dists = torch.nan_to_num(
+            train_dists, nan=train_dists[~train_dists.isnan()].max().item()
+        )
         train_test_dists = pm.dist(X_test, X_train)
         train_test_dists = torch.nan_to_num(
             train_test_dists,
@@ -389,7 +442,9 @@ def benchmark(
         t2 = time.time()
         knn.fit(train_dists, y_train_np)
         t3 = time.time()
-        accs["knn"] = _score(train_test_dists, y_test_np, knn, use_torch=False, score=score)
+        accs["knn"] = _score(
+            train_test_dists, y_test_np, knn, use_torch=False, score=score
+        )
         accs["knn"]["time"] = t3 - t1
 
     # if "perceptron" in models:
@@ -413,16 +468,25 @@ def benchmark(
             t1 = time.time()
             ps_per.fit(X_train, y_train)
             t2 = time.time()
-            accs["ps_perceptron"] = _score(X_test, y_test_np, ps_per, use_torch=True, score=score)
+            accs["ps_perceptron"] = _score(
+                X_test, y_test_np, ps_per, use_torch=True, score=score
+            )
             accs["ps_perceptron"]["time"] = t2 - t1
         else:
-            warnings.warn("Product Space Perceptron is only implemented for classification tasks.", stacklevel=2)
+            warnings.warn(
+                "Product Space Perceptron is only implemented for classification tasks.",
+                stacklevel=2,
+            )
 
     if "svm" in models:
         # Get inner products for precomputed kernel matrix
         t1 = time.time()
-        train_ips = pm.manifold.component_inner(X_train[:, None], X_train[None, :]).sum(dim=-1)
-        train_test_ips = pm.manifold.component_inner(X_test[:, None], X_train[None, :]).sum(dim=-1)
+        train_ips = pm.manifold.component_inner(X_train[:, None], X_train[None, :]).sum(
+            dim=-1
+        )
+        train_test_ips = pm.manifold.component_inner(
+            X_test[:, None], X_train[None, :]
+        ).sum(dim=-1)
 
         # Convert to numpy
         train_ips = train_ips.detach().cpu().numpy()
@@ -434,7 +498,9 @@ def benchmark(
         t2 = time.time()
         svm.fit(train_ips, y_train_np)
         t3 = time.time()
-        accs["svm"] = _score(train_test_ips, y_test_np, svm, use_torch=False, score=score)
+        accs["svm"] = _score(
+            train_test_ips, y_test_np, svm, use_torch=False, score=score
+        )
         accs["svm"]["time"] = t3 - t1
 
     if "ps_svm" in models:
@@ -455,30 +521,71 @@ def benchmark(
         ).to(device)
         t1 = time.time()
         if task == "link_prediction":
-            kappa_mlp.fit(X_train_stereo, y_train, A=A_train, tqdm_prefix="kappa_mlp", **nn_train_kwargs)
+            kappa_mlp.fit(
+                X_train_stereo,
+                y_train,
+                A=A_train,
+                tqdm_prefix="kappa_mlp",
+                **nn_train_kwargs,
+            )
         else:
-            kappa_mlp.fit(X_train_stereo, y_train, A=None, tqdm_prefix="kappa_mlp", **nn_train_kwargs)
+            kappa_mlp.fit(
+                X_train_stereo,
+                y_train,
+                A=None,
+                tqdm_prefix="kappa_mlp",
+                **nn_train_kwargs,
+            )
         t2 = time.time()
         y_pred = kappa_mlp.predict(X_test_stereo, A=None)
-        accs["kappa_mlp"] = _score(None, y_test_np, kappa_mlp, y_pred_override=y_pred, use_torch=True, score=score)
+        accs["kappa_mlp"] = _score(
+            None,
+            y_test_np,
+            kappa_mlp,
+            y_pred_override=y_pred,
+            use_torch=True,
+            score=score,
+        )
         accs["kappa_mlp"]["time"] = t2 - t1
 
     if "ambient_mlp" in models:
         ambient_mlp = KappaGCN(pm=pm_euc, num_hidden=kappa_gcn_layers, **nn_kwargs).to(device)  # type: ignore
         t1 = time.time()
-        ambient_mlp.fit(X_train, y_train, A=None, tqdm_prefix="ambient_mlp", **nn_train_kwargs)
+        ambient_mlp.fit(
+            X_train, y_train, A=None, tqdm_prefix="ambient_mlp", **nn_train_kwargs
+        )
         t2 = time.time()
         y_pred = ambient_mlp.predict(X_test, A=None)
-        accs["ambient_mlp"] = _score(None, y_test_np, ambient_mlp, y_pred_override=y_pred, use_torch=True, score=score)
+        accs["ambient_mlp"] = _score(
+            None,
+            y_test_np,
+            ambient_mlp,
+            y_pred_override=y_pred,
+            use_torch=True,
+            score=score,
+        )
         accs["ambient_mlp"]["time"] = t2 - t1
 
     if "tangent_mlp" in models:
         tangent_mlp = KappaGCN(pm=pm_euc, num_hidden=kappa_gcn_layers, **nn_kwargs).to(device)  # type: ignore
         t1 = time.time()
-        tangent_mlp.fit(X_train_tangent, y_train, A=None, tqdm_prefix="tangent_mlp", **nn_train_kwargs)
+        tangent_mlp.fit(
+            X_train_tangent,
+            y_train,
+            A=None,
+            tqdm_prefix="tangent_mlp",
+            **nn_train_kwargs,
+        )
         t2 = time.time()
         y_pred = tangent_mlp.predict(X_test_tangent, A=None)
-        accs["tangent_mlp"] = _score(None, y_test_np, tangent_mlp, y_pred_override=y_pred, use_torch=True, score=score)
+        accs["tangent_mlp"] = _score(
+            None,
+            y_test_np,
+            tangent_mlp,
+            y_pred_override=y_pred,
+            use_torch=True,
+            score=score,
+        )
         accs["tangent_mlp"]["time"] = t2 - t1
 
     if "ambient_gcn" in models:
@@ -487,53 +594,87 @@ def benchmark(
         ambient_gcn.fit(X_train, y_train, A=A_train, **nn_train_kwargs)
         t2 = time.time()
         y_pred = ambient_gcn.predict(X_test, A=A_test)
-        accs["ambient_gcn"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
+        accs["ambient_gcn"] = _score(
+            None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score
+        )
         accs["ambient_gcn"]["time"] = t2 - t1
 
     if "tangent_gcn" in models:
         tangent_gcn = KappaGCN(pm=pm_euc, num_hidden=kappa_gcn_layers, **nn_kwargs).to(device)  # type: ignore
         t1 = time.time()
-        tangent_gcn.fit(X_train_tangent, y_train, A=A_train, tqdm_prefix="tangent_gcn", **nn_train_kwargs)
+        tangent_gcn.fit(
+            X_train_tangent,
+            y_train,
+            A=A_train,
+            tqdm_prefix="tangent_gcn",
+            **nn_train_kwargs,
+        )
         t2 = time.time()
         y_pred = tangent_gcn.predict(X_test_tangent, A=A_test)
-        accs["tangent_gcn"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
+        accs["tangent_gcn"] = _score(
+            None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score
+        )
         accs["tangent_gcn"]["time"] = t2 - t1
 
     if "kappa_gcn" in models:
         assert isinstance(X_test_stereo, torch.Tensor)
         kappa_gcn = KappaGCN(pm=pm_stereo, num_hidden=kappa_gcn_layers, task=task, output_dim=nn_outdim).to(device)  # type: ignore
         t1 = time.time()
-        kappa_gcn.fit(X_train_stereo, y_train, A=A_train, tqdm_prefix="kappa_gcn", **nn_train_kwargs)
+        kappa_gcn.fit(
+            X_train_stereo,
+            y_train,
+            A=A_train,
+            tqdm_prefix="kappa_gcn",
+            **nn_train_kwargs,
+        )
         t2 = time.time()
         y_pred = kappa_gcn.predict(X_test_stereo, A=A_test)
-        accs["kappa_gcn"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
+        accs["kappa_gcn"] = _score(
+            None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score
+        )
         accs["kappa_gcn"]["time"] = t2 - t1
 
     if "kappa_mlr" in models:
         kappa_mlr = KappaGCN(pm=pm_stereo, num_hidden=0, task=task, output_dim=nn_outdim).to(device)  # type: ignore
         t1 = time.time()
-        kappa_mlr.fit(X_train_stereo, y_train, A=None, tqdm_prefix="kappa_mlr", **nn_train_kwargs)
+        kappa_mlr.fit(
+            X_train_stereo, y_train, A=None, tqdm_prefix="kappa_mlr", **nn_train_kwargs
+        )
         t2 = time.time()
         y_pred = kappa_mlr.predict(X_test_stereo, A=None)
-        accs["kappa_mlr"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
+        accs["kappa_mlr"] = _score(
+            None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score
+        )
         accs["kappa_mlr"]["time"] = t2 - t1
 
     if "tangent_mlr" in models:
         tangent_mlr = KappaGCN(pm=pm_euc, num_hidden=0, task=task, output_dim=nn_outdim).to(device)  # type: ignore
         t1 = time.time()
-        tangent_mlr.fit(X_train_tangent, y_train, A=None, tqdm_prefix="tangent_mlr", **nn_train_kwargs)
+        tangent_mlr.fit(
+            X_train_tangent,
+            y_train,
+            A=None,
+            tqdm_prefix="tangent_mlr",
+            **nn_train_kwargs,
+        )
         t2 = time.time()
         y_pred = tangent_mlr.predict(X_test_tangent, A=None)
-        accs["tangent_mlr"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
+        accs["tangent_mlr"] = _score(
+            None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score
+        )
         accs["tangent_mlr"]["time"] = t2 - t1
 
     if "ambient_mlr" in models:
         ambient_mlr = KappaGCN(pm=pm_euc, num_hidden=0, task=task, output_dim=nn_outdim).to(device)  # type: ignore
         t1 = time.time()
-        ambient_mlr.fit(X_train, y_train, A=None, tqdm_prefix="ambient_mlr", **nn_train_kwargs)
+        ambient_mlr.fit(
+            X_train, y_train, A=None, tqdm_prefix="ambient_mlr", **nn_train_kwargs
+        )
         t2 = time.time()
         y_pred = ambient_mlr.predict(X_test, A=None)
-        accs["ambient_mlr"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
+        accs["ambient_mlr"] = _score(
+            None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score
+        )
         accs["ambient_mlr"]["time"] = t2 - t1
 
     # return accs

--- a/manify/utils/benchmarks.py
+++ b/manify/utils/benchmarks.py
@@ -40,12 +40,7 @@ if TYPE_CHECKING:
     TASKTYPE: TypeAlias = Literal["classification", "regression", "link_prediction"]
 
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
-from sklearn.metrics import (
-    accuracy_score,
-    f1_score,
-    mean_squared_error,
-    root_mean_squared_error,
-)
+from sklearn.metrics import accuracy_score, f1_score, mean_squared_error, root_mean_squared_error
 from sklearn.model_selection import train_test_split
 from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 from sklearn.svm import SVC, SVR
@@ -258,18 +253,9 @@ def benchmark(
     X_test_tangent = pm.logmap(X_test).detach()
 
     # Get numpy versions
-    X_train_np, X_test_np = (
-        X_train.detach().cpu().numpy(),
-        X_test.detach().cpu().numpy(),
-    )
-    y_train_np, y_test_np = (
-        y_train.detach().cpu().numpy(),
-        y_test.detach().cpu().numpy(),
-    )
-    X_train_tangent_np, X_test_tangent_np = (
-        X_train_tangent.cpu().numpy(),
-        X_test_tangent.cpu().numpy(),
-    )
+    X_train_np, X_test_np = X_train.detach().cpu().numpy(), X_test.detach().cpu().numpy()
+    y_train_np, y_test_np = y_train.detach().cpu().numpy(), y_test.detach().cpu().numpy()
+    X_train_tangent_np, X_test_tangent_np = X_train_tangent.cpu().numpy(), X_test_tangent.cpu().numpy()
 
     # Get stereographic version
     pm_stereo, X_train_stereo, X_test_stereo = pm.stereographic(X_train, X_test)
@@ -301,16 +287,8 @@ def benchmark(
         A_test = A_test.to(device).detach()
 
     # Aggregate arguments
-    tree_kwargs = {
-        "max_depth": max_depth,
-        "min_samples_leaf": min_samples_leaf,
-        "min_samples_split": min_samples_split,
-    }
-    prod_kwargs = {
-        "use_special_dims": use_special_dims,
-        "n_features": n_features,
-        "batch_size": batch_size,
-    }
+    tree_kwargs = {"max_depth": max_depth, "min_samples_leaf": min_samples_leaf, "min_samples_split": min_samples_split}
+    prod_kwargs = {"use_special_dims": use_special_dims, "n_features": n_features, "batch_size": batch_size}
     rf_kwargs = {"n_estimators": n_estimators, "n_jobs": -1, "random_state": seed}
     nn_outdim = 1 if task == "regression" else len(torch.unique(y))
     nn_kwargs = {"task": task, "output_dim": nn_outdim}
@@ -434,10 +412,7 @@ def benchmark(
             accs["ps_perceptron"] = _score(X_test, y_test_np, ps_per, use_torch=True, score=score)
             accs["ps_perceptron"]["time"] = t2 - t1
         else:
-            warnings.warn(
-                "Product Space Perceptron is only implemented for classification tasks.",
-                stacklevel=2,
-            )
+            warnings.warn("Product Space Perceptron is only implemented for classification tasks.", stacklevel=2)
 
     if "svm" in models:
         # Get inner products for precomputed kernel matrix
@@ -476,31 +451,12 @@ def benchmark(
         ).to(device)
         t1 = time.time()
         if task == "link_prediction":
-            kappa_mlp.fit(
-                X_train_stereo,
-                y_train,
-                A=A_train,
-                tqdm_prefix="kappa_mlp",
-                **nn_train_kwargs,
-            )
+            kappa_mlp.fit(X_train_stereo, y_train, A=A_train, tqdm_prefix="kappa_mlp", **nn_train_kwargs)
         else:
-            kappa_mlp.fit(
-                X_train_stereo,
-                y_train,
-                A=None,
-                tqdm_prefix="kappa_mlp",
-                **nn_train_kwargs,
-            )
+            kappa_mlp.fit(X_train_stereo, y_train, A=None, tqdm_prefix="kappa_mlp", **nn_train_kwargs)
         t2 = time.time()
         y_pred = kappa_mlp.predict(X_test_stereo, A=None)
-        accs["kappa_mlp"] = _score(
-            None,
-            y_test_np,
-            kappa_mlp,
-            y_pred_override=y_pred,
-            use_torch=True,
-            score=score,
-        )
+        accs["kappa_mlp"] = _score(None, y_test_np, kappa_mlp, y_pred_override=y_pred, use_torch=True, score=score)
         accs["kappa_mlp"]["time"] = t2 - t1
 
     if "ambient_mlp" in models:
@@ -509,36 +465,16 @@ def benchmark(
         ambient_mlp.fit(X_train, y_train, A=None, tqdm_prefix="ambient_mlp", **nn_train_kwargs)
         t2 = time.time()
         y_pred = ambient_mlp.predict(X_test, A=None)
-        accs["ambient_mlp"] = _score(
-            None,
-            y_test_np,
-            ambient_mlp,
-            y_pred_override=y_pred,
-            use_torch=True,
-            score=score,
-        )
+        accs["ambient_mlp"] = _score(None, y_test_np, ambient_mlp, y_pred_override=y_pred, use_torch=True, score=score)
         accs["ambient_mlp"]["time"] = t2 - t1
 
     if "tangent_mlp" in models:
         tangent_mlp = KappaGCN(pm=pm_euc, num_hidden=kappa_gcn_layers, **nn_kwargs).to(device)  # type: ignore
         t1 = time.time()
-        tangent_mlp.fit(
-            X_train_tangent,
-            y_train,
-            A=None,
-            tqdm_prefix="tangent_mlp",
-            **nn_train_kwargs,
-        )
+        tangent_mlp.fit(X_train_tangent, y_train, A=None, tqdm_prefix="tangent_mlp", **nn_train_kwargs)
         t2 = time.time()
         y_pred = tangent_mlp.predict(X_test_tangent, A=None)
-        accs["tangent_mlp"] = _score(
-            None,
-            y_test_np,
-            tangent_mlp,
-            y_pred_override=y_pred,
-            use_torch=True,
-            score=score,
-        )
+        accs["tangent_mlp"] = _score(None, y_test_np, tangent_mlp, y_pred_override=y_pred, use_torch=True, score=score)
         accs["tangent_mlp"]["time"] = t2 - t1
 
     if "ambient_gcn" in models:
@@ -553,13 +489,7 @@ def benchmark(
     if "tangent_gcn" in models:
         tangent_gcn = KappaGCN(pm=pm_euc, num_hidden=kappa_gcn_layers, **nn_kwargs).to(device)  # type: ignore
         t1 = time.time()
-        tangent_gcn.fit(
-            X_train_tangent,
-            y_train,
-            A=A_train,
-            tqdm_prefix="tangent_gcn",
-            **nn_train_kwargs,
-        )
+        tangent_gcn.fit(X_train_tangent, y_train, A=A_train, tqdm_prefix="tangent_gcn", **nn_train_kwargs)
         t2 = time.time()
         y_pred = tangent_gcn.predict(X_test_tangent, A=A_test)
         accs["tangent_gcn"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
@@ -569,13 +499,7 @@ def benchmark(
         assert isinstance(X_test_stereo, torch.Tensor)
         kappa_gcn = KappaGCN(pm=pm_stereo, num_hidden=kappa_gcn_layers, task=task, output_dim=nn_outdim).to(device)  # type: ignore
         t1 = time.time()
-        kappa_gcn.fit(
-            X_train_stereo,
-            y_train,
-            A=A_train,
-            tqdm_prefix="kappa_gcn",
-            **nn_train_kwargs,
-        )
+        kappa_gcn.fit(X_train_stereo, y_train, A=A_train, tqdm_prefix="kappa_gcn", **nn_train_kwargs)
         t2 = time.time()
         y_pred = kappa_gcn.predict(X_test_stereo, A=A_test)
         accs["kappa_gcn"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
@@ -593,13 +517,7 @@ def benchmark(
     if "tangent_mlr" in models:
         tangent_mlr = KappaGCN(pm=pm_euc, num_hidden=0, task=task, output_dim=nn_outdim).to(device)  # type: ignore
         t1 = time.time()
-        tangent_mlr.fit(
-            X_train_tangent,
-            y_train,
-            A=None,
-            tqdm_prefix="tangent_mlr",
-            **nn_train_kwargs,
-        )
+        tangent_mlr.fit(X_train_tangent, y_train, A=None, tqdm_prefix="tangent_mlr", **nn_train_kwargs)
         t2 = time.time()
         y_pred = tangent_mlr.predict(X_test_tangent, A=None)
         accs["tangent_mlr"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,5 +77,4 @@ markdown_extensions:
       generic: true
 
 extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -187,6 +187,16 @@ def test_regression_score_is_r2():
     assert score <= 1.0, "R^2 cannot exceed 1.0"
 
 
+def test_get_a_hat_does_not_mutate_input():
+    """get_A_hat must not modify the adjacency/distance matrix passed in."""
+    A = torch.tensor([[float("nan"), 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0]])
+    A_original = A.clone()
+    _ = get_A_hat(A)
+    assert torch.equal(A.isnan(), A_original.isnan()), "NaNs in input were overwritten"
+    finite = ~A_original.isnan()
+    assert torch.allclose(A[finite], A_original[finite]), "Input matrix was mutated"
+
+
 def test_all_link_predictors():
     print("Testing basic link predictor functionality")
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -1,4 +1,5 @@
 import torch
+from sklearn.metrics import r2_score
 from sklearn.model_selection import train_test_split
 
 from manify.manifolds import ProductManifold
@@ -165,8 +166,6 @@ def test_all_regressors():
 
 def test_regression_score_is_r2():
     """Regression .score() must return R^2 (higher is better), matching sklearn."""
-    from sklearn.metrics import r2_score
-
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
     X, y = pm.gaussian_mixture(
         num_points=100, num_classes=2, seed=42, task="regression"

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -7,53 +7,35 @@ from manify.predictors.decision_tree import ProductSpaceDT, ProductSpaceRF
 from manify.predictors.kappa_gcn import KappaGCN, get_A_hat
 from manify.predictors.perceptron import ProductSpacePerceptron
 from manify.predictors.svm import ProductSpaceSVM
-from manify.utils.link_prediction import (
-    make_link_prediction_dataset,
-    split_link_prediction_dataset,
-)
+from manify.utils.link_prediction import make_link_prediction_dataset, split_link_prediction_dataset
 
 
-def _test_base_classifier(
-    model, X_train, X_test, y_train, y_test, task="classification"
-):
+def _test_base_classifier(model, X_train, X_test, y_train, y_test, task="classification"):
     model.fit(X_train, y_train)
 
     preds = model.predict(X_test)
-    assert (
-        preds.shape[0] == X_test.shape[0]
-    ), "Predictions should match the number of test samples"
+    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
 
     if task == "classification":
         probs = model.predict_proba(X_test)
-        assert probs.shape == (
-            X_test.shape[0],
-            2,
-        ), "Probabilities should match the number of test samples and classes"
+        assert probs.shape == (X_test.shape[0], 2), "Probabilities should match the number of test samples and classes"
         assert probs.ndim == 2, "Probabilities should be a 2D array"
-        assert (
-            torch.argmax(probs, dim=1) == preds
-        ).all(), "Predictions should match the class with the highest probability"
+        assert (torch.argmax(probs, dim=1) == preds).all(), (
+            "Predictions should match the class with the highest probability"
+        )
 
         accuracy = (preds == y_test).float().mean()
-        assert (
-            accuracy >= 0.5
-        ), f"Model {model.__class__.__name__} did not achieve sufficient accuracy"
+        assert accuracy >= 0.5, f"Model {model.__class__.__name__} did not achieve sufficient accuracy"
 
         score = model.score(X_test, y_test)
-        assert (
-            score >= 0.5
-        ), f"Model {model.__class__.__name__} did not achieve sufficient score"
-        assert (
-            score == accuracy
-        ), "Score and accuracy should match for classification tasks"
+        assert score >= 0.5, f"Model {model.__class__.__name__} did not achieve sufficient score"
+        assert score == accuracy, "Score and accuracy should match for classification tasks"
     elif task == "regression":
         pass  # No further tests are really possible for regression
 
 
-def _test_kappa_gcn_model(
-    model, X_train, X_test, y_train, y_test, pm, task="classification"
-):
+def _test_kappa_gcn_model(model, X_train, X_test, y_train, y_test, pm, task="classification"):
     X_train_kernel = torch.exp(-pm.pdist2(X_train))
     X_test_kernel = torch.exp(-pm.pdist2(X_test))
     A_train = get_A_hat(X_train_kernel)
@@ -61,29 +43,22 @@ def _test_kappa_gcn_model(
     model.fit(X_train, y_train, A=A_train, use_tqdm=False, epochs=100)
 
     preds = model.predict(X_test, A=A_test)
-    assert (
-        preds.shape[0] == X_test.shape[0]
-    ), "Predictions should match the number of test samples"
+    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
 
     if task == "classification":
         assert preds.ndim == 1, "Predictions should be a 1D array"
 
         probs = model.predict_proba(X_test, A=A_test)
-        assert probs.shape == (
-            X_test.shape[0],
-            2,
-        ), "Probabilities should match the number of test samples and classes"
-        assert (
-            torch.argmax(probs, dim=1) == preds
-        ).all(), "Predictions should match the class with the highest probability"
-        assert (
-            torch.argmax(probs, dim=1).shape[0] == preds.shape[0]
-        ), "The number of predicted classes should match the number of predictions"
+        assert probs.shape == (X_test.shape[0], 2), "Probabilities should match the number of test samples and classes"
+        assert (torch.argmax(probs, dim=1) == preds).all(), (
+            "Predictions should match the class with the highest probability"
+        )
+        assert torch.argmax(probs, dim=1).shape[0] == preds.shape[0], (
+            "The number of predicted classes should match the number of predictions"
+        )
 
         accuracy = (preds == y_test).float().mean()
-        assert (
-            accuracy >= 0.5
-        ), f"Model {model.__class__.__name__} did not achieve sufficient accuracy"
+        assert accuracy >= 0.5, f"Model {model.__class__.__name__} did not achieve sufficient accuracy"
     elif task == "regression":
         assert preds.ndim == 1, "Predictions should be a 1D array"
     elif task == "link_prediction":
@@ -92,18 +67,14 @@ def _test_kappa_gcn_model(
             X_test.shape[0],
             X_test.shape[0],
         ), "Link prediction predictions should match the number of pairs"
-        assert (
-            (preds == 0) | (preds == 1)
-        ).all(), "Link prediction predictions should be binary (0 or 1)"
+        assert ((preds == 0) | (preds == 1)).all(), "Link prediction predictions should be binary (0 or 1)"
 
 
 def test_all_classifiers():
     print("Testing basic classifier functionality")
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
     X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.2, random_state=42, stratify=y
-    )
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42, stratify=y)
 
     # Init models
     for model_class in [
@@ -119,9 +90,7 @@ def test_all_classifiers():
     # Kappa-GCN needs its own thing
     pm_stereo, X_train_stereo, X_test_stereo = pm.stereographic(X_train, X_test)
     kappa_gcn = KappaGCN(pm=pm_stereo, output_dim=2, num_hidden=2)
-    _test_kappa_gcn_model(
-        kappa_gcn, X_train_stereo, X_test_stereo, y_train, y_test, pm=pm_stereo
-    )
+    _test_kappa_gcn_model(kappa_gcn, X_train_stereo, X_test_stereo, y_train, y_test, pm=pm_stereo)
 
     print("All classifiers tested successfully.")
 
@@ -129,12 +98,8 @@ def test_all_classifiers():
 def test_all_regressors():
     print("Testing basic regressor functionality")
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
-    X, y = pm.gaussian_mixture(
-        num_points=100, num_classes=2, seed=42, task="regression"
-    )
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.2, random_state=42
-    )
+    X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42, task="regression")
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
     # Init models
     for model_class in [
@@ -144,22 +109,12 @@ def test_all_regressors():
         # ProductSpaceSVM,
     ]:
         model = model_class(pm=pm, task="regression")
-        _test_base_classifier(
-            model, X_train, X_test, y_train, y_test, task="regression"
-        )
+        _test_base_classifier(model, X_train, X_test, y_train, y_test, task="regression")
 
     # Kappa-GCN needs its own thing
     pm_stereo, X_train_stereo, X_test_stereo = pm.stereographic(X_train, X_test)
     kappa_gcn = KappaGCN(pm=pm_stereo, output_dim=1, num_hidden=2, task="regression")
-    _test_kappa_gcn_model(
-        kappa_gcn,
-        X_train_stereo,
-        X_test_stereo,
-        y_train,
-        y_test,
-        pm=pm_stereo,
-        task="regression",
-    )
+    _test_kappa_gcn_model(kappa_gcn, X_train_stereo, X_test_stereo, y_train, y_test, pm=pm_stereo, task="regression")
 
     print("All regressors tested successfully.")
 
@@ -167,12 +122,8 @@ def test_all_regressors():
 def test_regression_score_is_r2():
     """Regression .score() must return R^2 (higher is better), matching sklearn."""
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
-    X, y = pm.gaussian_mixture(
-        num_points=100, num_classes=2, seed=42, task="regression"
-    )
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.2, random_state=42
-    )
+    X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42, task="regression")
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
     model = ProductSpaceDT(pm=pm, task="regression")
     model.fit(X_train, y_train)
@@ -180,9 +131,7 @@ def test_regression_score_is_r2():
 
     score = model.score(X_test, y_test)
     expected = r2_score(y_test.numpy(), preds.numpy())
-    assert (
-        abs(score - expected) < 1e-5
-    ), f"score {score} should equal r2_score {expected}"
+    assert abs(score - expected) < 1e-5, f"score {score} should equal r2_score {expected}"
     assert score <= 1.0, "R^2 cannot exceed 1.0"
 
 
@@ -199,9 +148,7 @@ def test_get_a_hat_does_not_mutate_input():
 def test_all_link_predictors():
     print("Testing basic link predictor functionality")
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
-    X, _ = pm.gaussian_mixture(
-        num_points=100, num_classes=1, seed=42, task="classification"
-    )
+    X, _ = pm.gaussian_mixture(num_points=100, num_classes=1, seed=42, task="classification")
 
     # Compute adjacency matrix: top 3 neighbors for each node
     with torch.no_grad():
@@ -214,15 +161,11 @@ def test_all_link_predictors():
         adj = ((adj + adj.t()) > 0).float()
 
     # Create link prediction dataset
-    X_lp, y_lp, pm_with_dists = make_link_prediction_dataset(
-        X_embed=X, pm=pm, adj=adj, add_dists=True
-    )
+    X_lp, y_lp, pm_with_dists = make_link_prediction_dataset(X_embed=X, pm=pm, adj=adj, add_dists=True)
 
     # Use split_link_prediction_dataset for train/test split
-    X_train_lp, X_test_lp, y_train_lp, y_test_lp, idx_train, idx_test = (
-        split_link_prediction_dataset(
-            X_lp, y_lp, test_size=0.2, random_state=42, downsample=20
-        )
+    X_train_lp, X_test_lp, y_train_lp, y_test_lp, idx_train, idx_test = split_link_prediction_dataset(
+        X_lp, y_lp, test_size=0.2, random_state=42, downsample=20
     )
 
     # Test traditional models - these treat data as a classification task
@@ -246,9 +189,7 @@ def test_all_link_predictors():
     pm_stereo, X_train_stereo, X_test_stereo = pm.stereographic(X_train, X_test)
 
     # Test KappaGCN
-    kappa_gcn = KappaGCN(
-        pm=pm_stereo, output_dim=2, num_hidden=2, task="link_prediction"
-    )
+    kappa_gcn = KappaGCN(pm=pm_stereo, output_dim=2, num_hidden=2, task="link_prediction")
     _test_kappa_gcn_model(
         kappa_gcn,
         X_train_stereo,
@@ -264,111 +205,77 @@ def test_all_link_predictors():
 def test_random_forest_batch():
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
     X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.2, random_state=42
-    )
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
     batch_sizes = [1, 10, None]
     preds_list = []
 
     for batch_size in batch_sizes:
-        rf = ProductSpaceRF(
-            pm=pm,
-            batch_size=batch_size,
-            n_estimators=2,
-            random_state=42,
-            max_features="none",
-        )
+        rf = ProductSpaceRF(pm=pm, batch_size=batch_size, n_estimators=2, random_state=42, max_features="none")
         rf.fit(X_train, y_train)
         preds = rf.predict(X_test)
-        assert (
-            preds.shape[0] == X_test.shape[0]
-        ), "Predictions should match the number of test samples"
+        assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
         assert preds.ndim == 1, "Predictions should be a 1D array"
-        assert (
-            preds == y_test
-        ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+        assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
         preds_list.append(preds)
 
     # Check equality for all outputs
     for i in range(len(preds_list)):
         for j in range(i + 1, len(preds_list)):
-            assert torch.allclose(
-                preds_list[i], preds_list[j]
-            ), f"Predictions should be the same for batch sizes {batch_sizes[i]} and {batch_sizes[j]}"
+            assert torch.allclose(preds_list[i], preds_list[j]), (
+                f"Predictions should be the same for batch sizes {batch_sizes[i]} and {batch_sizes[j]}"
+            )
 
 
 def test_decision_tree_special_dims_ablate_midpoints():
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
     X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.2, random_state=42
-    )
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
     # Special dims
     rf = ProductSpaceRF(pm=pm, use_special_dims=True, n_estimators=2, random_state=42)
     rf.fit(X_train, y_train)
     preds = rf.predict(X_test)
-    assert (
-        preds.shape[0] == X_test.shape[0]
-    ), "Predictions should match the number of test samples"
+    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
-    assert (
-        preds == y_test
-    ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+    assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
 
     # Ablate midpoints
     rf = ProductSpaceRF(pm=pm, ablate_midpoints=True, n_estimators=2, random_state=42)
     rf.fit(X_train, y_train)
     preds = rf.predict(X_test)
-    assert (
-        preds.shape[0] == X_test.shape[0]
-    ), "Predictions should match the number of test samples"
+    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
-    assert (
-        preds == y_test
-    ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+    assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
 
 
 def test_random_forest_max_features():
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
     X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.2, random_state=42
-    )
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
     # max_features = sqrt
     dt = ProductSpaceRF(pm=pm, max_features="sqrt", n_estimators=2)
     dt.fit(X_train, y_train)
     preds = dt.predict(X_test)
-    assert (
-        preds.shape[0] == X_test.shape[0]
-    ), "Predictions should match the number of test samples"
+    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
-    assert (
-        preds == y_test
-    ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+    assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
 
     # max_features = log2
     dt = ProductSpaceRF(pm=pm, max_features="log2", n_estimators=2)
     dt.fit(X_train, y_train)
     preds = dt.predict(X_test)
-    assert (
-        preds.shape[0] == X_test.shape[0]
-    ), "Predictions should match the number of test samples"
+    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
-    assert (
-        preds == y_test
-    ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+    assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
 
     # max_features = int: each tree should subsample exactly that many feature columns
     n_features_int = 3
     rf = ProductSpaceRF(pm=pm, max_features=n_features_int, n_estimators=2)
     rf.fit(X_train, y_train)
     n_cols = rf.trees[0].permutations.shape[0]
-    assert (
-        n_cols == n_features_int
-    ), f"Expected {n_features_int} subsampled features, got {n_cols}"
+    assert n_cols == n_features_int, f"Expected {n_features_int} subsampled features, got {n_cols}"
     assert all(tree.permutations.shape[0] == n_features_int for tree in rf.trees)
 
     # max_features larger than the available columns should clamp to the number of columns

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -6,35 +6,53 @@ from manify.predictors.decision_tree import ProductSpaceDT, ProductSpaceRF
 from manify.predictors.kappa_gcn import KappaGCN, get_A_hat
 from manify.predictors.perceptron import ProductSpacePerceptron
 from manify.predictors.svm import ProductSpaceSVM
-from manify.utils.link_prediction import make_link_prediction_dataset, split_link_prediction_dataset
+from manify.utils.link_prediction import (
+    make_link_prediction_dataset,
+    split_link_prediction_dataset,
+)
 
 
-def _test_base_classifier(model, X_train, X_test, y_train, y_test, task="classification"):
+def _test_base_classifier(
+    model, X_train, X_test, y_train, y_test, task="classification"
+):
     model.fit(X_train, y_train)
 
     preds = model.predict(X_test)
-    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
+    assert (
+        preds.shape[0] == X_test.shape[0]
+    ), "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
 
     if task == "classification":
         probs = model.predict_proba(X_test)
-        assert probs.shape == (X_test.shape[0], 2), "Probabilities should match the number of test samples and classes"
+        assert probs.shape == (
+            X_test.shape[0],
+            2,
+        ), "Probabilities should match the number of test samples and classes"
         assert probs.ndim == 2, "Probabilities should be a 2D array"
-        assert (torch.argmax(probs, dim=1) == preds).all(), (
-            "Predictions should match the class with the highest probability"
-        )
+        assert (
+            torch.argmax(probs, dim=1) == preds
+        ).all(), "Predictions should match the class with the highest probability"
 
         accuracy = (preds == y_test).float().mean()
-        assert accuracy >= 0.5, f"Model {model.__class__.__name__} did not achieve sufficient accuracy"
+        assert (
+            accuracy >= 0.5
+        ), f"Model {model.__class__.__name__} did not achieve sufficient accuracy"
 
         score = model.score(X_test, y_test)
-        assert score >= 0.5, f"Model {model.__class__.__name__} did not achieve sufficient score"
-        assert score == accuracy, "Score and accuracy should match for classification tasks"
+        assert (
+            score >= 0.5
+        ), f"Model {model.__class__.__name__} did not achieve sufficient score"
+        assert (
+            score == accuracy
+        ), "Score and accuracy should match for classification tasks"
     elif task == "regression":
         pass  # No further tests are really possible for regression
 
 
-def _test_kappa_gcn_model(model, X_train, X_test, y_train, y_test, pm, task="classification"):
+def _test_kappa_gcn_model(
+    model, X_train, X_test, y_train, y_test, pm, task="classification"
+):
     X_train_kernel = torch.exp(-pm.pdist2(X_train))
     X_test_kernel = torch.exp(-pm.pdist2(X_test))
     A_train = get_A_hat(X_train_kernel)
@@ -42,22 +60,29 @@ def _test_kappa_gcn_model(model, X_train, X_test, y_train, y_test, pm, task="cla
     model.fit(X_train, y_train, A=A_train, use_tqdm=False, epochs=100)
 
     preds = model.predict(X_test, A=A_test)
-    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
+    assert (
+        preds.shape[0] == X_test.shape[0]
+    ), "Predictions should match the number of test samples"
 
     if task == "classification":
         assert preds.ndim == 1, "Predictions should be a 1D array"
 
         probs = model.predict_proba(X_test, A=A_test)
-        assert probs.shape == (X_test.shape[0], 2), "Probabilities should match the number of test samples and classes"
-        assert (torch.argmax(probs, dim=1) == preds).all(), (
-            "Predictions should match the class with the highest probability"
-        )
-        assert torch.argmax(probs, dim=1).shape[0] == preds.shape[0], (
-            "The number of predicted classes should match the number of predictions"
-        )
+        assert probs.shape == (
+            X_test.shape[0],
+            2,
+        ), "Probabilities should match the number of test samples and classes"
+        assert (
+            torch.argmax(probs, dim=1) == preds
+        ).all(), "Predictions should match the class with the highest probability"
+        assert (
+            torch.argmax(probs, dim=1).shape[0] == preds.shape[0]
+        ), "The number of predicted classes should match the number of predictions"
 
         accuracy = (preds == y_test).float().mean()
-        assert accuracy >= 0.5, f"Model {model.__class__.__name__} did not achieve sufficient accuracy"
+        assert (
+            accuracy >= 0.5
+        ), f"Model {model.__class__.__name__} did not achieve sufficient accuracy"
     elif task == "regression":
         assert preds.ndim == 1, "Predictions should be a 1D array"
     elif task == "link_prediction":
@@ -66,14 +91,18 @@ def _test_kappa_gcn_model(model, X_train, X_test, y_train, y_test, pm, task="cla
             X_test.shape[0],
             X_test.shape[0],
         ), "Link prediction predictions should match the number of pairs"
-        assert ((preds == 0) | (preds == 1)).all(), "Link prediction predictions should be binary (0 or 1)"
+        assert (
+            (preds == 0) | (preds == 1)
+        ).all(), "Link prediction predictions should be binary (0 or 1)"
 
 
 def test_all_classifiers():
     print("Testing basic classifier functionality")
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
     X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42, stratify=y)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42, stratify=y
+    )
 
     # Init models
     for model_class in [
@@ -89,7 +118,9 @@ def test_all_classifiers():
     # Kappa-GCN needs its own thing
     pm_stereo, X_train_stereo, X_test_stereo = pm.stereographic(X_train, X_test)
     kappa_gcn = KappaGCN(pm=pm_stereo, output_dim=2, num_hidden=2)
-    _test_kappa_gcn_model(kappa_gcn, X_train_stereo, X_test_stereo, y_train, y_test, pm=pm_stereo)
+    _test_kappa_gcn_model(
+        kappa_gcn, X_train_stereo, X_test_stereo, y_train, y_test, pm=pm_stereo
+    )
 
     print("All classifiers tested successfully.")
 
@@ -97,8 +128,12 @@ def test_all_classifiers():
 def test_all_regressors():
     print("Testing basic regressor functionality")
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
-    X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42, task="regression")
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    X, y = pm.gaussian_mixture(
+        num_points=100, num_classes=2, seed=42, task="regression"
+    )
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
 
     # Init models
     for model_class in [
@@ -108,12 +143,22 @@ def test_all_regressors():
         # ProductSpaceSVM,
     ]:
         model = model_class(pm=pm, task="regression")
-        _test_base_classifier(model, X_train, X_test, y_train, y_test, task="regression")
+        _test_base_classifier(
+            model, X_train, X_test, y_train, y_test, task="regression"
+        )
 
     # Kappa-GCN needs its own thing
     pm_stereo, X_train_stereo, X_test_stereo = pm.stereographic(X_train, X_test)
     kappa_gcn = KappaGCN(pm=pm_stereo, output_dim=1, num_hidden=2, task="regression")
-    _test_kappa_gcn_model(kappa_gcn, X_train_stereo, X_test_stereo, y_train, y_test, pm=pm_stereo, task="regression")
+    _test_kappa_gcn_model(
+        kappa_gcn,
+        X_train_stereo,
+        X_test_stereo,
+        y_train,
+        y_test,
+        pm=pm_stereo,
+        task="regression",
+    )
 
     print("All regressors tested successfully.")
 
@@ -121,7 +166,9 @@ def test_all_regressors():
 def test_all_link_predictors():
     print("Testing basic link predictor functionality")
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
-    X, _ = pm.gaussian_mixture(num_points=100, num_classes=1, seed=42, task="classification")
+    X, _ = pm.gaussian_mixture(
+        num_points=100, num_classes=1, seed=42, task="classification"
+    )
 
     # Compute adjacency matrix: top 3 neighbors for each node
     with torch.no_grad():
@@ -134,11 +181,15 @@ def test_all_link_predictors():
         adj = ((adj + adj.t()) > 0).float()
 
     # Create link prediction dataset
-    X_lp, y_lp, pm_with_dists = make_link_prediction_dataset(X_embed=X, pm=pm, adj=adj, add_dists=True)
+    X_lp, y_lp, pm_with_dists = make_link_prediction_dataset(
+        X_embed=X, pm=pm, adj=adj, add_dists=True
+    )
 
     # Use split_link_prediction_dataset for train/test split
-    X_train_lp, X_test_lp, y_train_lp, y_test_lp, idx_train, idx_test = split_link_prediction_dataset(
-        X_lp, y_lp, test_size=0.2, random_state=42, downsample=20
+    X_train_lp, X_test_lp, y_train_lp, y_test_lp, idx_train, idx_test = (
+        split_link_prediction_dataset(
+            X_lp, y_lp, test_size=0.2, random_state=42, downsample=20
+        )
     )
 
     # Test traditional models - these treat data as a classification task
@@ -162,7 +213,9 @@ def test_all_link_predictors():
     pm_stereo, X_train_stereo, X_test_stereo = pm.stereographic(X_train, X_test)
 
     # Test KappaGCN
-    kappa_gcn = KappaGCN(pm=pm_stereo, output_dim=2, num_hidden=2, task="link_prediction")
+    kappa_gcn = KappaGCN(
+        pm=pm_stereo, output_dim=2, num_hidden=2, task="link_prediction"
+    )
     _test_kappa_gcn_model(
         kappa_gcn,
         X_train_stereo,
@@ -178,67 +231,117 @@ def test_all_link_predictors():
 def test_random_forest_batch():
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
     X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
 
     batch_sizes = [1, 10, None]
     preds_list = []
 
     for batch_size in batch_sizes:
-        rf = ProductSpaceRF(pm=pm, batch_size=batch_size, n_estimators=2, random_state=42, max_features="none")
+        rf = ProductSpaceRF(
+            pm=pm,
+            batch_size=batch_size,
+            n_estimators=2,
+            random_state=42,
+            max_features="none",
+        )
         rf.fit(X_train, y_train)
         preds = rf.predict(X_test)
-        assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
+        assert (
+            preds.shape[0] == X_test.shape[0]
+        ), "Predictions should match the number of test samples"
         assert preds.ndim == 1, "Predictions should be a 1D array"
-        assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+        assert (
+            preds == y_test
+        ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
         preds_list.append(preds)
 
     # Check equality for all outputs
     for i in range(len(preds_list)):
         for j in range(i + 1, len(preds_list)):
-            assert torch.allclose(preds_list[i], preds_list[j]), (
-                f"Predictions should be the same for batch sizes {batch_sizes[i]} and {batch_sizes[j]}"
-            )
+            assert torch.allclose(
+                preds_list[i], preds_list[j]
+            ), f"Predictions should be the same for batch sizes {batch_sizes[i]} and {batch_sizes[j]}"
 
 
 def test_decision_tree_special_dims_ablate_midpoints():
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
     X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
 
     # Special dims
     rf = ProductSpaceRF(pm=pm, use_special_dims=True, n_estimators=2, random_state=42)
     rf.fit(X_train, y_train)
     preds = rf.predict(X_test)
-    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
+    assert (
+        preds.shape[0] == X_test.shape[0]
+    ), "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
-    assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+    assert (
+        preds == y_test
+    ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
 
     # Ablate midpoints
     rf = ProductSpaceRF(pm=pm, ablate_midpoints=True, n_estimators=2, random_state=42)
     rf.fit(X_train, y_train)
     preds = rf.predict(X_test)
-    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
+    assert (
+        preds.shape[0] == X_test.shape[0]
+    ), "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
-    assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+    assert (
+        preds == y_test
+    ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
 
 
 def test_random_forest_max_features():
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
     X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
 
     # max_features = sqrt
     dt = ProductSpaceRF(pm=pm, max_features="sqrt", n_estimators=2)
     dt.fit(X_train, y_train)
     preds = dt.predict(X_test)
-    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
+    assert (
+        preds.shape[0] == X_test.shape[0]
+    ), "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
-    assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+    assert (
+        preds == y_test
+    ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
 
     # max_features = log2
     dt = ProductSpaceRF(pm=pm, max_features="log2", n_estimators=2)
     dt.fit(X_train, y_train)
     preds = dt.predict(X_test)
-    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
+    assert (
+        preds.shape[0] == X_test.shape[0]
+    ), "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
-    assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+    assert (
+        preds == y_test
+    ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+
+    # max_features = int: each tree should subsample exactly that many feature columns
+    n_features_int = 3
+    rf = ProductSpaceRF(pm=pm, max_features=n_features_int, n_estimators=2)
+    rf.fit(X_train, y_train)
+    n_cols = rf.trees[0].permutations.shape[0]
+    assert (
+        n_cols == n_features_int
+    ), f"Expected {n_features_int} subsampled features, got {n_cols}"
+    assert all(tree.permutations.shape[0] == n_features_int for tree in rf.trees)
+
+    # max_features larger than the available columns should clamp to the number of columns
+    rf = ProductSpaceRF(pm=pm, max_features=10_000, n_estimators=2)
+    rf.fit(X_train, y_train)
+    total_angles = rf.trees[0].permutations.shape[0]
+    rf_all = ProductSpaceRF(pm=pm, max_features="none", n_estimators=2)
+    rf_all.fit(X_train, y_train)
+    assert total_angles == rf_all.trees[0].permutations.shape[0]

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -163,6 +163,30 @@ def test_all_regressors():
     print("All regressors tested successfully.")
 
 
+def test_regression_score_is_r2():
+    """Regression .score() must return R^2 (higher is better), matching sklearn."""
+    from sklearn.metrics import r2_score
+
+    pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
+    X, y = pm.gaussian_mixture(
+        num_points=100, num_classes=2, seed=42, task="regression"
+    )
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
+
+    model = ProductSpaceDT(pm=pm, task="regression")
+    model.fit(X_train, y_train)
+    preds = model.predict(X_test)
+
+    score = model.score(X_test, y_test)
+    expected = r2_score(y_test.numpy(), preds.numpy())
+    assert (
+        abs(score - expected) < 1e-5
+    ), f"score {score} should equal r2_score {expected}"
+    assert score <= 1.0, "R^2 cannot exceed 1.0"
+
+
 def test_all_link_predictors():
     print("Testing basic link predictor functionality")
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])


### PR DESCRIPTION
Fixes a batch of bugs found during a review pass, plus the suite blockers that surfaced once the tests ran in a clean env. Full suite is green (23 passed).

## Correctness fixes
- **ProductSpaceRF integer `max_features`**: was using *all* features for any int value (`n_cols_sample = n_cols`); now `min(max_features, n_cols)`, type hint widened to `int | Literal[...]`. + test.
- **Regression `score()` returned MSE, not R²**: contradicted the docstring and `RegressorMixin` (higher-is-better). Now weighted R²; weighted accuracy also fixed to divide by `Σw`. `predictor_pipeline` updated to negate (both metrics now higher-is-better). + test vs `sklearn.r2_score`.
- **`arsin_k` curvature arg**: `StereographicLogits` passed `kappa*abs(kappa)` (= sign·κ²); geoopt's `arsin_k` already scales by `sqrt(|κ|)`, so the arg must be `kappa`. Confirmed by the Euclidean κ→0 limit `4·za`.
- **`get_A_hat` mutated its input** (NaN→0 in place); now non-mutating. + test.
- **`__version__`** was stale `0.0.2`; now derived from `importlib.metadata` (tracks pyproject).

## Suite blockers (pre-existing, surfaced in clean venv)
- **ProductSpaceSVM** `float(eps_var.value)` failed under numpy 2.x (1-element ndarray); index before `float()`.
- **`predict`/`score` `**kwargs: dict`** made beartype reject `predict(X, A=tensor)`; now `Any`.
- **Undefined/invalid annotations** (`Dict`/`List`/`Tuple` unimported; `torch.Tensor["..."]`) corrected.

## Other
- Remove `polyfill.io` from mkdocs `extra_javascript` (defunct/supply-chain risk).

## Benchmark fix
- `benchmark()` regression default `score` no longer crashes its own assertion; deduped validation block.

Verified locally: `pytest` → **23 passed**.