### PR TITLE
Fix documentation inconsistencies

### DIFF
--- a/manify/clustering/fuzzy_kmeans.py
+++ b/manify/clustering/fuzzy_kmeans.py
@@ -58,7 +58,7 @@ class RiemannianFuzzyKMeans(BaseEstimator, ClusterMixin):
 
     Args:
         n_clusters: The number of clusters to form.
-        manifold: An initialized manifold object (from manifolds.py) on which clustering will be performed.
+        pm: An initialized manifold object (from manifolds.py) on which clustering will be performed.
         m: Fuzzifier parameter. Controls the softness of the partition.
         lr: Learning rate for the optimizer.
         max_iter: Maximum number of iterations for the optimization.

--- a/manify/curvature_estimation/_pipelines.py
+++ b/manify/curvature_estimation/_pipelines.py
@@ -23,7 +23,7 @@ def distortion_pipeline(
     embedder_init_kwargs: dict[str, Any] | None = None,
     embedder_fit_kwargs: dict[str, Any] | None = None,
 ) -> float:
-    """Builds a distortion‐based pipeline function for greedy signature selection.
+    """Distortion‐based pipeline function for greedy signature selection.
 
     Args:
         pm: Product manifold to use for the pipeline.
@@ -32,8 +32,7 @@ def distortion_pipeline(
         embedder_fit_kwargs: Additional keyword arguments for fitting the embedder model.
 
     Returns:
-        A function f(signature) → loss, where signature is a list
-        of (curvature, dim) tuples.
+        The distortion loss of the embeddings learned on the given product manifold.
     """
     embedder_init_kwargs = embedder_init_kwargs or {}
     embedder_fit_kwargs = embedder_fit_kwargs or {}
@@ -64,7 +63,7 @@ def predictor_pipeline(
     model_init_kwargs: dict[str, Any] | None = None,
     model_fit_kwargs: dict[str, Any] | None = None,
 ) -> float:
-    """Builds a classifier‐based pipeline function for greedy signature selection.
+    """Classifier‐based pipeline function for greedy signature selection.
 
     Args:
         pm: Product manifold to use for the pipeline.

--- a/manify/curvature_estimation/greedy_method.py
+++ b/manify/curvature_estimation/greedy_method.py
@@ -38,6 +38,7 @@ def greedy_signature_selection(
 
     Returns:
         optimal_pm: Optimized product manifold with the selected signature.
+        loss_history: List of loss values at each accepted greedy step.
     """
     # Initialize variables
     signature: list[tuple[float, int]] = []

--- a/manify/embedders/vae.py
+++ b/manify/embedders/vae.py
@@ -110,11 +110,9 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         r"""Encodes input data to obtain latent means and log-variances in the manifold.
 
         This method processes input data through the encoder network to obtain parameters of the approximate posterior
-        distribution $q(z|x)$ in the product manifold space. For non-Euclidean components, the method:
-
-        1. Gets tangent space vectors and log-variances from the encoder,
-        2. Projects tangent vectors to the ambient space by adding zeros in the right places, and
-        3. Maps the ambient space vectors to the manifold using the exponential map
+        distribution $q(z|x)$ in the product manifold space. The encoder output is split into a mean (in the tangent
+        plane at the origin) and a log-variance. Projection of the tangent mean to the ambient space and the exponential
+        map onto the manifold are deferred to `forward`.
 
         Args:
             x: Input data tensor.
@@ -306,7 +304,7 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
             clip_grad: Whether to apply gradient clipping.
 
         Returns:
-            losses: List of loss values recorded during training.
+            self: Fitted ProductSpaceVAE instance.
         """
         if self.random_state is not None:
             torch.manual_seed(self.random_state)

--- a/manify/predictors/_base.py
+++ b/manify/predictors/_base.py
@@ -115,7 +115,7 @@ class BasePredictor(BaseEstimator, ABC):
             **kwargs: Additional keyword arguments that get passed to `self.predict_proba()`.
 
         Returns:
-            X_proba: Predicted probabilities for the input features.
+            predictions: Predicted classes (classification/link_prediction) or values (regression).
         """
         if self.task == "regression":
             return self.predict_proba(X=X, **kwargs).squeeze(-1)

--- a/manify/predictors/decision_tree.py
+++ b/manify/predictors/decision_tree.py
@@ -334,13 +334,11 @@ class ProductSpaceDT(BasePredictor):
         Args:
             X: (batch, ambient_dim) tensor of coordinates
             y: (batch,) tensor of labels
-            include_special_dims: whether to include special dimensions as a new Euclidean component
 
         Outputs:
-            X: (batch, intrinsic_dim) tensor of angles
-            y: (batch, n_classes) tensor of one-hot labels
-            classes: (n_classes,) tensor of classes with original labels
-            M: (batch, intrinsic_dim, batch) tensor of comparisons
+            angles: (batch, intrinsic_dim) tensor of angles
+            labels: (batch, n_classes) tensor of one-hot labels
+            comparisons: (batch, intrinsic_dim, batch) tensor of comparisons
         """
         # Ensure X and y are tensors
         if not torch.is_tensor(X):
@@ -489,11 +487,11 @@ class ProductSpaceDT(BasePredictor):
         """Reworked fit function for new version of ProductDT.
 
         Args:
-            X: (batch, ambient_dim) tensor of trainind data (ambient coordinate representation)
+            X: (batch, ambient_dim) tensor of training data (ambient coordinate representation)
             y: (batch,) tensor of labels (integer representation)
 
         Returns:
-            None (fits tree in place)
+            self: The fitted decision tree.
         """
         # Pre-preprocessing step: aggregate special dimensions into a new Euclidean component
         if self.use_special_dims:

--- a/manify/predictors/kappa_gcn.py
+++ b/manify/predictors/kappa_gcn.py
@@ -169,7 +169,7 @@ class KappaGCN(BasePredictor, torch.nn.Module):
             X (torch.Tensor): Feature matrix.
             y (torch.Tensor): Labels for training nodes.
             A (torch.Tensor): Adjacency or distance matrix.
-            epochs: Number of training epochs (default=200).
+            epochs: Number of training epochs (default=2000).
             lr: Learning rate (default=1e-2).
             use_tqdm: Whether to use tqdm for progress bar.
             tqdm_prefix: Prefix for tqdm progress bar.

--- a/manify/predictors/nn/layers.py
+++ b/manify/predictors/nn/layers.py
@@ -325,7 +325,6 @@ class FermiDiracDecoder(nn.Module):
         Args:
             X: Node embeddings
             A_hat: Ignored (for compatibility)
-            return_pairwise: If True, return full pairwise matrix. If False, return flattened upper triangle.
 
         Returns:
             Edge probabilities (logits, apply sigmoid if needed)

--- a/manify/utils/benchmarks.py
+++ b/manify/utils/benchmarks.py
@@ -154,8 +154,6 @@ def benchmark(
             Defaults to None.
         A_test: Testing adjacency matrix with shape (n_samples, n_samples).
             Defaults to None.
-        hidden_dims: List of hidden layer dimensions for neural networks.
-            Defaults to None.
         epochs: Number of training epochs for iterative models. Defaults to 4000.
         lr: Learning rate for gradient-based optimization. Defaults to 1e-4.
         kappa_gcn_layers: Number of layers in GCN models. Defaults to 1.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,16 +55,12 @@ nav:
       - Midpoint: reference/predictors/_midpoint.md
       - Neural Network Layers:
         - Overview: reference/predictors/nn/index.md
-        - Kappa-GCN Layer: reference/predictors/nn/layers/kappa_gcn_layer.md
-        - Kappa Sequential Container: reference/predictors/nn/layers/kappa_sequential.md
-        - Stereographic Logits: reference/predictors/nn/layers/stereographic_logits.md
-        - Fermi-Dirac Decoder: reference/predictors/nn/layers/fermi_dirac_decoder.md
+        - Layers: reference/predictors/nn/layers.md
     - Utils:
       - Overview: reference/utils/index.md
       - Benchmarks: reference/utils/benchmarks.md
       - Dataloaders: reference/utils/dataloaders.md
       - Link Prediction: reference/utils/link_prediction.md
-      - Preprocessing: reference/utils/preprocessing.md
       - Visualization: reference/utils/visualization.md
 
 markdown_extensions:


### PR DESCRIPTION
Documentation-only pass (docstrings, mkdocs nav). No logic changes.

## Fixes
- `KappaGCN.fit`: epochs default 200 → **2000** (matches signature).
- Removed documented args that don't exist: `benchmark`'s `hidden_dims`, `ProductSpaceDT._preprocess`'s `include_special_dims`, `FermiDiracDecoder.forward`'s `return_pairwise`.
- Corrected `Returns:` blocks: `fit` returns `self` (not None / a loss list); `predict` returns classes/values (not probabilities); `_preprocess` returns `(angles, labels, comparisons)`.
- `RiemannianFuzzyKMeans` Args: `manifold` → `pm`.
- `greedy_signature_selection` now documents `(optimal_pm, loss_history)`.
- `distortion_pipeline`/`predictor_pipeline`: return a float, not "a function".
- `ProductSpaceVAE.encode` description matched to actual behavior (projection/expmap happen in `forward`).
- mkdocs nav: removed entries pointing at non-generated pages (per-class NN layer pages; `utils/preprocessing.md`).

> Note: an earlier `__version__` bump was dropped from this branch — it's handled in #32 via `importlib.metadata`.

## Suspected code bugs (deferred to #32 / follow-ups, NOT changed here)
The same defects fixed in #32: unimported `Dict`/`List`/`Tuple`, and `torch.Tensor["num_heads 1 1"]`.

Recommended merge order: **after #32** (this branch is off `main`, whose suite has the pre-existing failures #32 fixes).