### PR TITLE
Speed up tests: working HuggingFace cache + offline reuse

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,14 @@ permissions:
   contents: read
   pull-requests: write
 
-jobs:  
+# Pin a stable Hugging Face cache root for every job/step. `datasets`/`huggingface_hub`
+# resolve their cache under $HF_HOME, so fixing it here guarantees the path we cache with
+# actions/cache is exactly the path the library reads/writes. Relying on the platform default
+# (~/.cache/huggingface) is fragile and silently breaks if the default ever changes.
+env:
+  HF_HOME: ${{ github.workspace }}/.hf_cache
+
+jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -28,6 +35,27 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
+
+      # Restore the Hugging Face dataset cache. test_embedders / test_curvature_estimation
+      # call load_hf, so even this job needs the datasets. Key is stable across runs but
+      # versioned by the dataset list so adding/removing datasets invalidates it.
+      - name: Cache HuggingFace datasets
+        id: hf-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.HF_HOME }}
+          key: ${{ runner.os }}-huggingface-${{ hashFiles('tests/conftest.py', 'tests/test_utils.py') }}
+          restore-keys: |
+            ${{ runner.os }}-huggingface-
+
+      # On a cache hit, run datasets fully offline so load_dataset serves from the restored
+      # cache with zero network round-trips (no per-dataset revision check, no Hub rate limits).
+      # On a miss we stay online so the run can download and populate the cache for next time.
+      - name: Enable HuggingFace offline mode on cache hit
+        if: steps.hf-cache.outputs.cache-hit == 'true'
+        run: |
+          echo "HF_HUB_OFFLINE=1" >> "$GITHUB_ENV"
+          echo "HF_DATASETS_OFFLINE=1" >> "$GITHUB_ENV"
 
       - name: Install dependencies
         run: |
@@ -75,7 +103,7 @@ jobs:
   # Dataloaders run in parallel, for speed
   test-dataloaders:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -87,13 +115,19 @@ jobs:
           cache: "pip"
 
       - name: Cache HuggingFace datasets
+        id: hf-cache
         uses: actions/cache@v4
         with:
-          path: ~/.cache/huggingface
-          key: ${{ runner.os }}-huggingface-dataloaders-v1
+          path: ${{ env.HF_HOME }}
+          key: ${{ runner.os }}-huggingface-${{ hashFiles('tests/conftest.py', 'tests/test_utils.py') }}
           restore-keys: |
-            ${{ runner.os }}-huggingface-dataloaders-
             ${{ runner.os }}-huggingface-
+
+      - name: Enable HuggingFace offline mode on cache hit
+        if: steps.hf-cache.outputs.cache-hit == 'true'
+        run: |
+          echo "HF_HUB_OFFLINE=1" >> "$GITHUB_ENV"
+          echo "HF_DATASETS_OFFLINE=1" >> "$GITHUB_ENV"
 
       - name: Install dependencies
         run: |
@@ -112,4 +146,3 @@ jobs:
           verbose: true
           flags: dataloaders
           name: dataloaders
-

--- a/manify/utils/dataloaders.py
+++ b/manify/utils/dataloaders.py
@@ -33,6 +33,7 @@ Earlier versions of Manify included scripts to process raw data, which we have r
 
 from __future__ import annotations
 
+import functools
 from typing import TYPE_CHECKING
 
 import torch
@@ -42,28 +43,36 @@ if TYPE_CHECKING:
     from jaxtyping import Float, Real
 
 
-def load_hf(
-    name: str, namespace: str = "manify"
+@functools.cache
+def _load_hf_cached(
+    name: str, namespace: str
 ) -> tuple[
-    Float[torch.Tensor, "n_points ..."] | None,  # features
-    Float[torch.Tensor, "n_points n_points"] | None,  # pairwise dists
-    Float[torch.Tensor, "n_points n_points"] | None,  # adjacency labels
-    Real[torch.Tensor, "n_points"] | None,  # labels
+    Float[torch.Tensor, "n_points ..."] | None,
+    Float[torch.Tensor, "n_points n_points"] | None,
+    Float[torch.Tensor, "n_points n_points"] | None,
+    Real[torch.Tensor, "n_points"] | None,
 ]:
-    """Load a dataset from HuggingFace Hub at {namespace}/{name}.
+    """In-process memoized implementation of :func:`load_hf`.
+
+    Results are cached per ``(name, namespace)`` for the lifetime of the process so that
+    repeatedly loading the same dataset (e.g. across multiple tests in a single pytest run)
+    only resolves and decodes the dataset once. The Hugging Face on-disk cache and the
+    ``HF_HUB_OFFLINE`` / ``HF_DATASETS_OFFLINE`` environment variables are still honored by
+    :func:`datasets.load_dataset`, so this layer composes with the local cache.
+
+    Args:
+        name: The dataset name within the namespace.
+        namespace: The Hugging Face namespace/owner of the dataset.
 
     Returns:
-        features: The features for each node, if any
-        dists: The pairwise distance matrix over all nodes, if any
-        adj: The adjacency matrix over all nodes, if any
-        labels: The (classification or regression) labels for each node, if any
+        The same 4-tuple as :func:`load_hf`.
     """
-    # 1) fetch the single‑row dataset
+    # 1) fetch the single-row dataset
     ds = load_dataset(f"{namespace}/{name}")
     data = ds.get("train", ds)  # use "train" split if available, else the only split
     row = data[0]
 
-    # 2) helper to turn lists → torch (or None)
+    # 2) helper to turn lists -> torch (or None)
     def to_tensor(key: str, dtype: torch.dtype) -> torch.Tensor | None:
         vals = row.get(key, [])
         if not vals:
@@ -85,3 +94,28 @@ def load_hf(
         labels = None
 
     return feats, dists, adj, labels
+
+
+def load_hf(
+    name: str, namespace: str = "manify"
+) -> tuple[
+    Float[torch.Tensor, "n_points ..."] | None,  # features
+    Float[torch.Tensor, "n_points n_points"] | None,  # pairwise dists
+    Float[torch.Tensor, "n_points n_points"] | None,  # adjacency labels
+    Real[torch.Tensor, "n_points"] | None,  # labels
+]:
+    """Load a dataset from HuggingFace Hub at {namespace}/{name}.
+
+    Results are memoized per ``(name, namespace)`` for the lifetime of the process, so loading
+    the same dataset repeatedly (common across a test run) only resolves and decodes it once.
+    The Hugging Face on-disk cache and the ``HF_HUB_OFFLINE`` / ``HF_DATASETS_OFFLINE``
+    environment variables are honored by the underlying :func:`datasets.load_dataset` call, so
+    setting offline mode reuses the local cache without any network access.
+
+    Returns:
+        features: The features for each node, if any
+        dists: The pairwise distance matrix over all nodes, if any
+        adj: The adjacency matrix over all nodes, if any
+        labels: The (classification or regression) labels for each node, if any
+    """
+    return _load_hf_cached(name, namespace)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,128 @@
+"""Shared pytest fixtures and configuration for the manify test suite.
+
+This module centralizes Hugging Face dataset handling so that:
+
+1. The on-disk Hugging Face cache is reused across tests and across CI runs. When a cache
+   is already populated (locally or restored by ``actions/cache`` in CI), we flip
+   ``datasets`` into offline mode so that no per-dataset network round-trip (revision /
+   metadata check) is performed. With ``datasets >= 2`` an online ``load_dataset`` call
+   costs ~1-1.5s per dataset *even when fully cached* and is subject to unauthenticated
+   Hub rate limiting; offline reuse of the same cache is ~0.1s and never flakes.
+
+2. ``load_hf`` results are memoized within a run (see ``manify.utils.dataloaders``), so a
+   dataset requested by several tests is only decoded once.
+
+The offline switch is conditional: if the expected datasets are not present in the cache
+(e.g. a cold CI run before the cache exists), we leave ``datasets`` online so the first run
+can populate the cache, which ``actions/cache`` then saves for subsequent runs.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+# Datasets pulled by the test suite via ``load_hf`` (namespace ``manify``). Kept in sync with
+# tests/test_utils.py::test_dataloaders and the load_hf calls in other test modules. Used both
+# to detect whether the local cache is warm and to pre-warm/memoize datasets for the session.
+_HF_DATASETS: tuple[str, ...] = (
+    "cities",
+    "cs_phds",
+    "polblogs",
+    "polbooks",
+    "cora",
+    "citeseer",
+    "karate_club",
+    "lesmis",
+    "adjnoun",
+    "football",
+    "dolphins",
+    "blood_cells",
+    "lymphoma",
+    "cifar_100",
+    "mnist",
+    "temperature",
+    "landmasses",
+    "neuron_33",
+    "neuron_46",
+    "traffic",
+    "qiita",
+)
+
+
+def _hf_home() -> Path:
+    """Return the Hugging Face home directory that ``datasets`` will actually use.
+
+    Honors ``HF_HOME`` if set, otherwise falls back to the platform default
+    (``~/.cache/huggingface``). This mirrors how ``huggingface_hub`` resolves the cache root,
+    so the path we probe is the same one ``load_dataset`` reads and writes.
+    """
+    hf_home = os.environ.get("HF_HOME")
+    if hf_home:
+        return Path(hf_home)
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".cache"
+    return base / "huggingface"
+
+
+def _cache_is_warm() -> bool:
+    """Heuristically determine whether the manify datasets are already cached on disk.
+
+    We consider the cache warm if the ``hub`` cache directory contains entries for the manify
+    datasets. This is intentionally lenient: any cached manify dataset flips us to offline mode,
+    because a partial cache plus offline mode still avoids network round-trips for the cached
+    datasets, and ``datasets`` will raise clearly if a genuinely-missing dataset is requested.
+    """
+    hub_dir = _hf_home() / "hub"
+    if not hub_dir.is_dir():
+        return False
+    return any(p.name.startswith("datasets--manify--") for p in hub_dir.iterdir())
+
+
+@pytest.fixture(scope="session", autouse=True)
+def hf_offline_when_cached() -> None:
+    """Enable Hugging Face offline mode for the session when the dataset cache is warm.
+
+    Setting ``HF_HUB_OFFLINE`` / ``HF_DATASETS_OFFLINE`` makes ``datasets.load_dataset`` serve
+    the manify datasets directly from the local cache with no network access, eliminating the
+    per-dataset revision check (~1-1.5s each) and Hub rate-limit flakiness. If the cache is cold
+    (no manify datasets present), we stay online so the first run can download and populate it.
+
+    An explicit ``HF_HUB_OFFLINE`` already set in the environment (e.g. by CI after a cache hit)
+    is always respected and never overridden.
+    """
+    if os.environ.get("HF_HUB_OFFLINE") is not None:
+        # Caller (e.g. CI) has already decided; respect it. CI sets this before the test process
+        # starts, so the library reads it at import time and no runtime patching is needed.
+        return
+    if _cache_is_warm():
+        os.environ["HF_HUB_OFFLINE"] = "1"
+        os.environ["HF_DATASETS_OFFLINE"] = "1"
+        _force_offline_runtime()
+
+
+def _force_offline_runtime() -> None:
+    """Flip ``datasets``/``huggingface_hub`` into offline mode at runtime.
+
+    ``datasets`` and ``huggingface_hub`` read ``HF_HUB_OFFLINE`` into module-level config at
+    import time. Since ``datasets`` is already imported (via ``manify.utils.dataloaders``) by the
+    time this session fixture runs, setting the environment variable alone is too late. We also
+    patch the already-loaded config objects so ``load_dataset`` actually serves from the local
+    cache without any network access. This is best-effort across library versions.
+    """
+    try:
+        import datasets.config as ds_config  # noqa: PLC0415 - patch the already-imported config
+
+        ds_config.HF_HUB_OFFLINE = True
+        if hasattr(ds_config, "HF_DATASETS_OFFLINE"):
+            ds_config.HF_DATASETS_OFFLINE = True
+    except Exception:  # noqa: BLE001 - offline mode is an optimization, never fatal
+        pass
+    try:
+        import huggingface_hub.constants as hub_constants  # noqa: PLC0415 - patch loaded config
+
+        hub_constants.HF_HUB_OFFLINE = True
+    except Exception:  # noqa: BLE001
+        pass


### PR DESCRIPTION
Makes the HuggingFace dataset caching actually save time in CI, and memoizes `load_hf` within a run.

## Root cause (why caching didn't help before)
The old workflow *did* restore `~/.cache/huggingface`, but:
1. **Online mode still pays a Hub round-trip per dataset even with a warm cache** — measured ~1.5s/dataset (×21 ≈ 30s/run), plus unauthenticated rate-limit flakiness. Restoring bytes doesn't help if `datasets` still phones home for a revision check.
2. **No stable `HF_HOME`** — the cached path relied on the runner default; fragile.
3. **The main `test` job had no HF cache at all**, yet it also calls `load_hf`.

## Changes
- **`manify/utils/dataloaders.py`** (additive; signature/returns unchanged): memoize via `functools.cache` so a dataset requested by multiple tests is decoded once (repeat call 1.0s → ~5µs).
- **`tests/conftest.py`** (new): session-scoped autouse fixture that flips `datasets` to **offline at runtime** when the cache is warm (handles the gotcha that `HF_HUB_OFFLINE` is read at import time, before the fixture runs, by patching the already-loaded config). Cold cache → stays online to populate. Honors an explicit `HF_HUB_OFFLINE` (CI).
- **`.github/workflows/test.yml`**: stable `HF_HOME=$GITHUB_WORKSPACE/.hf_cache`; HF cache on **both** jobs; on exact cache-hit, export `HF_HUB_OFFLINE=1` so the test process starts offline with zero network; on miss, stays online to repopulate.

## Validation (local)
- Integrated with #32: full suite **23 passed**.
- Forced-offline run of `test_dataloaders`: **1 passed**, all 21 datasets served from cache with no network ("offline mode is enabled").

## Follow-up / trade-off
- Cache key hashes test files, not dataset revisions: a Hub-side dataset change won't refresh a warm CI cache until the key bumps (add a `-vN` suffix to force). Intended trade for speed/stability.

Recommended merge order: **after #32** (this branch is off `main`, whose suite has the pre-existing failures #32 fixes).