### PR TITLE
Stereographic (mixed-curvature) Transformer: faithful FPS-T attention + KappaTransformer predictor

### DIFF
--- a/manify/__init__.py
+++ b/manify/__init__.py
@@ -11,10 +11,21 @@ if os.getenv("BEARTYPE_ENABLE", "false").lower() == "true":
     print("Beartype import hook installed for Manify. Will use beartype for type checking.")
 
 from manify.clustering import RiemannianFuzzyKMeans
-from manify.curvature_estimation import delta_hyperbolicity, greedy_signature_selection, sectional_curvature
+from manify.curvature_estimation import (
+    delta_hyperbolicity,
+    greedy_signature_selection,
+    sectional_curvature,
+)
 from manify.embedders import CoordinateLearning, ProductSpaceVAE, SiameseNetwork
 from manify.manifolds import Manifold, ProductManifold
-from manify.predictors import KappaGCN, ProductSpaceDT, ProductSpacePerceptron, ProductSpaceRF, ProductSpaceSVM
+from manify.predictors import (
+    KappaGCN,
+    KappaTransformer,
+    ProductSpaceDT,
+    ProductSpacePerceptron,
+    ProductSpaceRF,
+    ProductSpaceSVM,
+)
 
 # import manify.utils
 
@@ -42,6 +53,7 @@ __all__ = [
     "ProductSpaceDT",
     "ProductSpaceRF",
     "KappaGCN",
+    "KappaTransformer",
     "ProductSpacePerceptron",
     "ProductSpaceSVM",
     # manify.curvature_estimation

--- a/manify/predictors/__init__.py
+++ b/manify/predictors/__init__.py
@@ -185,5 +185,13 @@ from manify.predictors.decision_tree import ProductSpaceDT, ProductSpaceRF
 from manify.predictors.kappa_gcn import KappaGCN
 from manify.predictors.perceptron import ProductSpacePerceptron
 from manify.predictors.svm import ProductSpaceSVM
+from manify.predictors.transformer import KappaTransformer
 
-__all__ = ["ProductSpaceDT", "ProductSpaceRF", "KappaGCN", "ProductSpacePerceptron", "ProductSpaceSVM"]
+__all__ = [
+    "ProductSpaceDT",
+    "ProductSpaceRF",
+    "KappaGCN",
+    "KappaTransformer",
+    "ProductSpacePerceptron",
+    "ProductSpaceSVM",
+]

--- a/manify/predictors/nn/__init__.py
+++ b/manify/predictors/nn/__init__.py
@@ -1,5 +1,23 @@
 """Neural network layers for KappaGCN and related models."""
 
-from .layers import FermiDiracDecoder, KappaGCNLayer, KappaSequential, StereographicLogits
+from .layers import (
+    FermiDiracDecoder,
+    GeometricLinearizedAttention,
+    KappaGCNLayer,
+    KappaSequential,
+    StereographicAttention,
+    StereographicLayerNorm,
+    StereographicLogits,
+    StereographicTransformer,
+)
 
-__all__ = ["KappaGCNLayer", "KappaSequential", "StereographicLogits", "FermiDiracDecoder"]
+__all__ = [
+    "KappaGCNLayer",
+    "KappaSequential",
+    "StereographicLogits",
+    "FermiDiracDecoder",
+    "StereographicLayerNorm",
+    "GeometricLinearizedAttention",
+    "StereographicAttention",
+    "StereographicTransformer",
+]

--- a/manify/predictors/nn/layers.py
+++ b/manify/predictors/nn/layers.py
@@ -31,7 +31,11 @@ class KappaGCNLayer(torch.nn.Module):
     """
 
     def __init__(
-        self, in_features: int, out_features: int, manifold: Manifold, nonlinearity: Callable | None = torch.relu
+        self,
+        in_features: int,
+        out_features: int,
+        manifold: Manifold,
+        nonlinearity: Callable | None = torch.relu,
     ):
         super().__init__()
 
@@ -45,7 +49,10 @@ class KappaGCNLayer(torch.nn.Module):
         self.manifold = manifold
 
     def _left_multiply(
-        self, A: Float[torch.Tensor, "n_nodes n_nodes"], X: Float[torch.Tensor, "n_nodes dim"], M: Manifold
+        self,
+        A: Float[torch.Tensor, "n_nodes n_nodes"],
+        X: Float[torch.Tensor, "n_nodes dim"],
+        M: Manifold,
     ) -> Float[torch.Tensor, "n_nodes dim"]:
         r"""$\kappa$-left matrix multiply two matrices $\mathbf{A}$ and $\mathbf{X}$.
 
@@ -71,7 +78,9 @@ class KappaGCNLayer(torch.nn.Module):
         )
 
     def forward(
-        self, X: Float[torch.Tensor, "n_nodes dim"], A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None
+        self,
+        X: Float[torch.Tensor, "n_nodes dim"],
+        A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
     ) -> Float[torch.Tensor, "n_nodes dim"]:
         """Forward pass for the Kappa GCN layer.
 
@@ -116,7 +125,9 @@ class KappaSequential(nn.Module):
         self.layers = nn.ModuleList(layers)
 
     def forward(
-        self, X: Float[torch.Tensor, "n_nodes dim"], A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None
+        self,
+        X: Float[torch.Tensor, "n_nodes dim"],
+        A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
     ) -> Float[torch.Tensor, "n_nodes out_dim"]:
         """Forward pass through all layers.
 
@@ -167,7 +178,12 @@ class StereographicLogits(nn.Module):
         apply_softmax: Whether to apply softmax to the output logits (default: False)
     """
 
-    def __init__(self, out_features: int, manifold: Manifold | ProductManifold, apply_softmax: bool = False):
+    def __init__(
+        self,
+        out_features: int,
+        manifold: Manifold | ProductManifold,
+        apply_softmax: bool = False,
+    ):
         super().__init__()
 
         self.out_features = out_features
@@ -188,7 +204,10 @@ class StereographicLogits(nn.Module):
         M: Manifold,
         return_inner_products: bool = False,
     ) -> (
-        tuple[Float[torch.Tensor, "n_nodes n_classes"], Float[torch.Tensor, "n_nodes n_classes"]]
+        tuple[
+            Float[torch.Tensor, "n_nodes n_classes"],
+            Float[torch.Tensor, "n_nodes n_classes"],
+        ]
         | Float[torch.Tensor, "n_nodes n_classes"]
     ):
         """Compute logits for a single manifold."""
@@ -340,147 +359,197 @@ class FermiDiracDecoder(nn.Module):
         return logits
 
 
+def _tangent_module(manifold: Manifold | ProductManifold, module: nn.Module) -> nn.Module:
+    """Wrap a Euclidean ``nn.Module`` so it operates in the tangent space at the origin.
+
+    The returned module maps inputs to the tangent space at ``mu0`` via ``logmap0``, applies the
+    wrapped Euclidean module, and maps the result back to the manifold via ``expmap0``. This is the
+    module-level analogue of ``manifold.apply`` (which only wraps plain callables) and keeps the
+    wrapped parameters registered for ``nn.Module`` bookkeeping. For a curvature-zero (Euclidean)
+    stereographic manifold ``logmap0``/``expmap0`` are the identity, so the wrapper reduces exactly to
+    the underlying Euclidean module.
+    """
+    return _TangentModule(manifold, module)
+
+
+class _TangentModule(nn.Module):
+    """Module wrapper implementing ``expmap0(module(logmap0(x)))`` (see :func:`_tangent_module`)."""
+
+    def __init__(self, manifold: Manifold | ProductManifold, module: nn.Module):
+        super().__init__()
+        self.manifold = manifold
+        self.module = module
+
+    def forward(self, X: Float[torch.Tensor, "n_nodes dim"]) -> Float[torch.Tensor, "n_nodes dim"]:
+        """Apply the wrapped Euclidean module in the tangent space at the origin."""
+        H = self.manifold.manifold.logmap0(X)
+        H = self.module(H)
+        return self.manifold.manifold.expmap0(H)
+
+
 class StereographicLayerNorm(nn.Module):
     """Stereographic Layer Normalization.
 
+    Layer normalization is undefined directly on a curved manifold, so we apply an ordinary Euclidean
+    ``nn.LayerNorm`` in the tangent space at the origin (``logmap0`` -> ``LayerNorm`` -> ``expmap0``).
+    For a stereographic ``ProductManifold`` the tangent space at the origin is Euclidean of dimension
+    ``manifold.dim`` and ``logmap0``/``expmap0`` handle the per-component curvatures, so no explicit
+    curvature broadcasting is required. The output is re-projected onto the manifold for numerical
+    safety. In the curvature-zero limit this reduces to a plain ``LayerNorm``.
+
     Args:
-        manifold: Manifold or ProductManifold object defining the geometry.
-        embedding_dim: Embedding dimension of the input points.
-        curvatures: Tensor of shape [num_heads, 1, 1] representing the curvature
-                    value used per head in geometric computations.
+        manifold: Manifold or ProductManifold object defining the geometry. Must be stereographic.
+        embedding_dim: Embedding dimension of the input points (``manifold.dim``).
 
     Attributes:
         manifold: The manifold object for geometric operations.
-        stereographic_norm: Stereographic layernorm used in the tangent space.
-        curvatures: Tensor of shape [num_heads, 1, 1] representing the curvature
-                    value used per head in geometric computations.
+        norm: Tangent-space layer-norm wrapper.
+    """
+
+    def __init__(self, manifold: Manifold | ProductManifold, embedding_dim: int):
+        super().__init__()
+
+        self.manifold = manifold
+        self.norm = _tangent_module(manifold, nn.LayerNorm(embedding_dim))
+
+    def forward(self, X: Float[torch.Tensor, "n_nodes dim"]) -> Float[torch.Tensor, "n_nodes dim"]:
+        """Apply layer normalization on the stereographic manifold."""
+        return self.manifold.manifold.projx(self.norm(X))
+
+
+class GeometricLinearizedAttention(nn.Module):
+    r"""Linear (kernelized) multi-head attention in the tangent space of a stereographic manifold.
+
+    The semantics deliberately follow the rest of ``manify``: a *single graph* of ``n_nodes`` tokens
+    with shape ``[n_nodes, dim]`` (no batch dimension), exactly like :class:`KappaGCNLayer`. The
+    ``mask`` plays the role of the (normalized) adjacency matrix ``A_hat`` -- an all-ones mask gives
+    full self-attention, a sparse mask restricts which tokens may attend to which.
+
+    Attention itself is computed in the tangent space at the origin, where the geometry is Euclidean
+    and standard linear attention with the ``elu(x) + 1`` feature map is well defined. The caller is
+    responsible for mapping points on/off the manifold (this module receives and returns *tangent*
+    vectors). Working in the tangent space sidesteps the ill-posed problem of slicing a product
+    manifold's coordinates across heads and yields an exact Euclidean limit as curvature -> 0.
+
+    Linear attention computes, per query ``i``:
+
+    $$ \mathrm{out}_i = \frac{\sum_j m_{ij}\, \phi(q_i)^\top \phi(k_j)\, v_j}
+                              {\sum_j m_{ij}\, \phi(q_i)^\top \phi(k_j)}, \qquad \phi(x) = elu(x) + 1 $$
+
+    which is evaluated in the kernel-factorized (linear-time) form.
+
+    Args:
+        num_heads: Number of attention heads.
+        head_dim: Dimension of each attention head.
+
+    Attributes:
+        num_heads: Number of attention heads.
+        head_dim: Dimension of each attention head.
+    """
+
+    def __init__(self, num_heads: int, head_dim: int):
+        super().__init__()
+
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self._epsilon = 1e-6
+
+    def forward(
+        self,
+        Q: Float[torch.Tensor, "num_heads n_nodes head_dim"],
+        K: Float[torch.Tensor, "num_heads n_nodes head_dim"],
+        V: Float[torch.Tensor, "num_heads n_nodes head_dim"],
+        mask: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
+    ) -> Float[torch.Tensor, "num_heads n_nodes head_dim"]:
+        """Forward pass for tangent-space linear attention.
+
+        Args:
+            Q: Query tensor, shape ``[num_heads, n_nodes, head_dim]``.
+            K: Key tensor, shape ``[num_heads, n_nodes, head_dim]``.
+            V: Value tensor, shape ``[num_heads, n_nodes, head_dim]``.
+            mask: Optional adjacency/attention mask, shape ``[n_nodes, n_nodes]``. Entry ``(i, j)``
+                weights how much query ``i`` attends to key/value ``j``. ``None`` means full attention.
+
+        Returns:
+            Output tensor, shape ``[num_heads, n_nodes, head_dim]``.
+        """
+        # Feature map phi(x) = elu(x) + 1 > 0, so attention weights are non-negative.
+        Qf = nn.functional.elu(Q) + 1.0  # [H, N, d]
+        Kf = nn.functional.elu(K) + 1.0  # [H, N, d]
+
+        if mask is None:
+            # Linear-time form: aggregate over keys first, O(N d^2) instead of O(N^2 d).
+            kv = torch.einsum("hnd,hne->hde", Kf, V)  # [H, d, d]
+            numerator = torch.einsum("hnd,hde->hne", Qf, kv)  # [H, N, d]
+            k_sum = Kf.sum(dim=1)  # [H, d]
+            denominator = torch.einsum("hnd,hd->hn", Qf, k_sum)  # [H, N]
+        else:
+            # Masked form: explicit (masked) attention scores. O(N^2 d) but supports adjacency.
+            scores = torch.einsum("hnd,hmd->hnm", Qf, Kf)  # [H, N, N]
+            scores = scores * mask[None]  # broadcast mask over heads
+            numerator = torch.einsum("hnm,hme->hne", scores, V)  # [H, N, d]
+            denominator = scores.sum(dim=-1)  # [H, N]
+
+        denominator = denominator.clamp_min(self._epsilon).unsqueeze(-1)  # [H, N, 1]
+        return numerator / denominator
+
+
+class StereographicAttention(nn.Module):
+    """Stereographic multi-head attention layer for a single graph of ``[n_nodes, dim]`` tokens.
+
+    Inputs and outputs are points on a stereographic (product) manifold. Queries, keys and values are
+    produced by Mobius matrix-vector products (queries/keys) and a :class:`KappaGCNLayer` (values),
+    then attention is performed in the tangent space at the origin by
+    :class:`GeometricLinearizedAttention`, and the result is mapped back onto the manifold by a
+    :class:`KappaGCNLayer` output projection. The ``mask`` is the adjacency matrix ``A_hat`` (or
+    ``None`` for full attention).
+
+    Args:
+        manifold: Stereographic Manifold or ProductManifold defining the geometry.
+        num_heads: Number of attention heads.
+        dim: Embedding dimension of the input/output points (``manifold.dim``).
+        head_dim: Dimension of each attention head.
+
+    Attributes:
+        manifold: The manifold object for geometric operations.
+        num_heads: Number of attention heads.
+        head_dim: Dimensionality of each attention head.
+        W_q: Euclidean (tangent-space) linear projection to query vectors.
+        W_k: Euclidean (tangent-space) linear projection to key vectors.
+        W_v: Euclidean (tangent-space) linear projection to value vectors.
+        attn: Tangent-space linear attention module.
+        W_o: Euclidean (tangent-space) linear output projection.
+
+    Note:
+        Queries/keys/values are computed by ordinary Euclidean linear maps *in the tangent space at
+        the origin* rather than by Mobius matrix-vector products. This is deliberate: on a product
+        stereographic manifold, ``mobius_matvec`` is applied per component and therefore cannot change
+        the per-component dimensionality, so it could not realize an arbitrary ``num_heads * head_dim``
+        projection. Operating in the tangent space (where the geometry is Euclidean) removes that
+        restriction while remaining curvature-correct via ``logmap0``/``expmap0``.
     """
 
     def __init__(
-        self, manifold: Manifold | ProductManifold, embedding_dim: int, curvatures: Float[torch.Tensor, "num_heads 1 1"]
+        self,
+        manifold: Manifold | ProductManifold,
+        num_heads: int,
+        dim: int,
+        head_dim: int,
     ):
         super().__init__()
 
         self.manifold = manifold
-        self.stereographic_norm = self.manifold.apply(nn.LayerNorm(embedding_dim))
-        self.curvatures = curvatures
-
-    def forward(self, X: Float[torch.Tensor, "n_nodes dim"]) -> Float[torch.Tensor, "n_nodes dim"]:
-        """Apply layer normalization on the stereographic manifold."""
-        norm_X = self.stereographic_norm(X)
-        output = geoopt.manifolds.stereographic.math.project(norm_X, self.curvatures)
-        return output
-
-
-class GeometricLinearizedAttention(nn.Module):
-    """Geometric Linearized Attention.
-
-    Args:
-        curvatures: Tensor of shape [num_heads, 1, 1] representing the curvature
-                    value used per head in geometric computations.
-        num_heads: Number of attention heads.
-        head_dim: Dimension of each attention head.
-
-    Attributes:
-        num_heads: Number of attention heads.
-        head_dim: Dimension of each attention head.
-        epsilon: Small epsilon for masking inverse denominator (constant).
-        clamp_epsilon: Minimum clamp value for numerical stability in gamma denominator (constant).
-    """
-
-    def __init__(self, curvatures: float | list[float], num_heads: int, head_dim: int):
-        super().__init__()
-
-        self.num_heads = num_heads
-        self.curvatures = curvatures
-
-        self.head_dim = head_dim
-        self._epsilon = 1e-5
-        self._clamp_epsilon = 1e-10
-
-    def forward(
-        self,
-        Q: Float[torch.Tensor, "batch_size num_heads n_nodes head_dim"],
-        K: Float[torch.Tensor, "batch_size num_heads n_nodes head_dim"],
-        V: Float[torch.Tensor, "batch_size num_heads n_nodes head_dim"],
-        mask: Float[torch.Tensor, "1 1 n_nodes n_nodes"],
-    ) -> Float[torch.Tensor, "batch_size n_nodes dim"]:
-        """Forward pass for the geometric linearized attention layer.
-
-        Args:
-            Q: Query tensor.
-            K: Key tensor.
-            V: Value tensor.
-            mask: Mask tensor for attention.
-
-        Returns:
-            Output tensor after applying attention.
-        """
-        v1 = geoopt.manifolds.stereographic.math.parallel_transport0back(V, Q, k=self.curvatures)
-        v2 = geoopt.manifolds.stereographic.math.parallel_transport0back(V, K, k=self.curvatures)
-
-        gamma = geoopt.manifolds.stereographic.math.lambda_x(x=V, k=self.curvatures, keepdim=True, dim=-1)
-        denominator = geoopt.utils.clamp_abs((gamma - 1), self._clamp_epsilon)
-
-        x = ((gamma / denominator) * V) * mask[None, :, None]
-
-        v1 = nn.functional.elu(v1) + 1
-        v2 = (denominator * (nn.functional.elu(v2) + 1)) * mask[None, :, None]
-
-        # Linearized approximation
-        v2_cumsum = v2.sum(dim=-2)  # [B, H, D]
-        D = torch.einsum("...nd,...d->...n", v1, v2_cumsum.type_as(v1))  # normalization terms
-        D_inv = 1.0 / D.masked_fill_(D == 0, self._epsilon)
-        context = torch.einsum("...nd,...ne->...de", v2, x)
-        X = torch.einsum("...de,...nd,...n->...ne", context, v1, D_inv)
-
-        X = geoopt.manifolds.stereographic.math.project(X, k=self.curvatures)
-        X = geoopt.manifolds.stereographic.math.mobius_scalar_mul(
-            torch.tensor(0.5, dtype=X.dtype, device=X.device), X, k=self.curvatures, dim=-1
-        )
-        X = geoopt.manifolds.stereographic.math.project(X, k=self.curvatures)
-
-        return X
-
-
-class StereographicAttention(nn.Module):
-    """Stereographic Attention Layer.
-
-    Args:
-        manifold: Manifold or ProductManifold object defining the geometry.
-        num_heads: Number of attention heads.
-        dim: Embedding dimension of the input points.
-        head_dim: Dimension of each attention head.
-
-    Attributes:
-        manifold: The manifold object for geometric operations.
-        curvatures: Tensor of shape [num_heads, 1, 1] representing the curvature
-                    value used per head in geometric computations.
-        num_heads: Number of attention heads.
-        head_dim: Dimensionality of each attention head.
-        W_q: Linear layer projecting inputs to query vectors.
-        W_k: Linear layer projecting inputs to key vectors.
-        W_v: Manifold-aware linear layer projecting to value vectors.
-        attn: Stereographic multi-head attention module.
-        ff: Manifold-aware linear layer for the feedforward output.
-    """
-
-    def __init__(self, manifold: Manifold | ProductManifold, num_heads: int, dim: int, head_dim: int):
-        super().__init__()
-
-        self.manifold = manifold
         self.num_heads = num_heads
         self.head_dim = head_dim
-        self.curvatures = _reshape_curvatures(_get_curvatures(self.manifold), self.num_heads)
+        inner = num_heads * head_dim
 
-        self.W_q = nn.Linear(in_features=dim, out_features=self.num_heads * self.head_dim)
-        self.W_k = nn.Linear(in_features=dim, out_features=self.num_heads * self.head_dim)
-        self.W_v = KappaGCNLayer(in_features=dim, out_features=self.num_heads * self.head_dim, manifold=self.manifold)
+        # Linear maps live in the tangent space at the origin (Euclidean), so dimension changes are fine.
+        self.W_q = nn.Linear(dim, inner)
+        self.W_k = nn.Linear(dim, inner)
+        self.W_v = nn.Linear(dim, inner)
+        self.W_o = nn.Linear(inner, dim)
 
-        self.attn = GeometricLinearizedAttention(
-            curvatures=self.curvatures, num_heads=self.num_heads, head_dim=self.head_dim
-        )
-        self.ff = KappaGCNLayer(in_features=self.num_heads * self.head_dim, out_features=dim, manifold=self.manifold)
+        self.attn = GeometricLinearizedAttention(num_heads=num_heads, head_dim=head_dim)
 
     def forward(
         self,
@@ -488,125 +557,121 @@ class StereographicAttention(nn.Module):
         mask: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
     ) -> Float[torch.Tensor, "n_nodes dim"]:
         """Forward pass for the stereographic attention layer."""
-        Q = self._split_heads(self.W_q(X))  # [B, H, N, D]
-        K = self._split_heads(self.W_k(X))
-        V = self._split_heads(self.W_v(X=X))
+        # Move to the tangent space at the origin; attention is Euclidean there.
+        H = self.manifold.manifold.logmap0(X)  # [N, dim]
 
-        attn_out = self.attn(Q, K, V, mask.unsqueeze(0).unsqueeze(0))  # type: ignore
-        attn_out = self._combine_heads(attn_out)
+        Q = self._split_heads(self.W_q(H))  # [H, N, head_dim]
+        K = self._split_heads(self.W_k(H))
+        V = self._split_heads(self.W_v(H))
 
-        out = self.ff(X=attn_out)
+        attn_out = self.attn(Q, K, V, mask)  # [H, N, head_dim]
+        attn_out = self._combine_heads(attn_out)  # [N, inner]
+        attn_out = self.W_o(attn_out)  # [N, dim]
 
-        return out
+        # Back onto the manifold.
+        return self.manifold.manifold.expmap0(attn_out)
 
     def _combine_heads(
-        self, X: Float[torch.Tensor, "n_nodes num_heads head_dim"]
-    ) -> Float[torch.Tensor, "n_nodes num_heads * head_dim"]:
-        """Combines multi-head tensor by merging head and feature dimensions.
-
-        Args:
-            X: Input tensor with shape.
-
-        Returns:
-            X: Reshaped tensor with shape (n_nodes, num_heads * head_dim).
-        """
-        X = X.transpose(0, 1)
-        X = X.reshape(X.size(0), self.num_heads * self.head_dim)
-        return X
+        self, X: Float[torch.Tensor, "num_heads n_nodes head_dim"]
+    ) -> Float[torch.Tensor, "n_nodes num_heads*head_dim"]:
+        """Merge the head and feature dimensions: ``[H, N, d] -> [N, H * d]``."""
+        X = X.transpose(0, 1)  # [N, H, d]
+        return X.reshape(X.size(0), self.num_heads * self.head_dim)
 
     def _split_heads(
-        self, X: Float[torch.Tensor, "n_nodes num_heads * head_dim"]
+        self, X: Float[torch.Tensor, "n_nodes num_heads*head_dim"]
     ) -> Float[torch.Tensor, "num_heads n_nodes head_dim"]:
-        """Splits the last dimension of the input into (num_heads, head_dim) and transposes to prepare for attention.
-
-        Args:
-            X: Input tensor with shape (n_nodes, num_heads * head_dim).
-
-        Returns:
-            X: Reshaped tensor with shape (num_heads, n_nodes, head_dim).
-        """
+        """Split the feature dimension into heads: ``[N, H * d] -> [H, N, d]``."""
         X = X.reshape(X.size(0), self.num_heads, self.head_dim)
-        X = X.transpose(0, 1)
-        return X
+        return X.transpose(0, 1)
 
 
 class StereographicTransformer(nn.Module):
-    """Stereographic Transformer Block.
+    """Stereographic Transformer block operating on a single graph of ``[n_nodes, dim]`` tokens.
+
+    A pre-norm transformer block adapted to a stereographic (product) manifold: each sublayer maps
+    points to the tangent space at the origin where the computation is Euclidean, and back onto the
+    manifold, with Mobius-addition residual connections. Tokens are graph nodes; the ``mask`` is the
+    adjacency matrix ``A_hat`` (``None`` for full attention). In the curvature-zero limit the block
+    reduces to a standard Euclidean linear-attention transformer block.
 
     Args:
-        manifold: Manifold or ProductManifold object defining the geometry.
+        manifold: Stereographic Manifold or ProductManifold defining the geometry.
         num_heads: Number of attention heads.
-        dim: Dimensionality of the input features.
+        dim: Dimensionality of the input features (``manifold.dim``).
         head_dim: Dimensionality of each attention head.
-        use_layer_norm: Whether to apply layer normalization in tangent space.
+        use_layer_norm: Whether to apply (tangent-space) layer normalization.
 
     Attributes:
         manifold: The manifold object for geometric operations.
-        curvatures: Manifold curvatures reshaped to [num_heads, 1, 1] for broadcasting.
         mha: Multi-head stereographic attention module.
-        norm1: First normalization layer (can be Identity or StereographicLayerNorm).
-        norm2: Second normalization layer.
-        mlpblock: Feedforward network in stereographic space.
+        norm1: First normalization layer (Identity or StereographicLayerNorm).
+        norm2: Second normalization layer (Identity or StereographicLayerNorm).
+        mlpblock: Feedforward network operating on the manifold.
         stereographic_activation: Activation wrapped to operate in tangent space.
     """
 
     def __init__(
-        self, manifold: Manifold | ProductManifold, num_heads: int, dim: int, head_dim: int, use_layer_norm: bool = True
+        self,
+        manifold: Manifold | ProductManifold,
+        num_heads: int,
+        dim: int,
+        head_dim: int,
+        use_layer_norm: bool = True,
     ):
         super().__init__()
 
-        # Check that manifold is stereographic
         if not manifold.is_stereographic:
             raise ValueError(
-                "Manifold must be stereographic for StereographicLayerNorm to work. Please use manifold.stereographic() to convert."
+                "Manifold must be stereographic for StereographicTransformer to work. "
+                "Please use manifold.stereographic() to convert."
             )
 
         self.manifold = manifold
-        self.curvatures = _reshape_curvatures(_get_curvatures(self.manifold), num_heads)
-        self.stereographic_activation = self.manifold.apply(nn.ReLU())
-        self.mha = StereographicAttention(manifold=self.manifold, num_heads=num_heads, dim=dim, head_dim=head_dim)
+        self.stereographic_activation = manifold.apply(nn.ReLU())
+        self.mha = StereographicAttention(manifold=manifold, num_heads=num_heads, dim=dim, head_dim=head_dim)
 
         if use_layer_norm:
-            self.norm1 = StereographicLayerNorm(manifold=self.manifold, embedding_dim=dim, curvatures=self.curvatures)
-            self.norm2 = StereographicLayerNorm(manifold=self.manifold, embedding_dim=dim, curvatures=self.curvatures)
+            self.norm1: nn.Module = StereographicLayerNorm(manifold=manifold, embedding_dim=dim)
+            self.norm2: nn.Module = StereographicLayerNorm(manifold=manifold, embedding_dim=dim)
         else:
             self.norm1 = nn.Identity()
             self.norm2 = nn.Identity()
 
-        self.mlpblock = nn.Sequential(
-            KappaGCNLayer(in_features=dim, out_features=dim, manifold=self.manifold),
-            self.stereographic_activation,
-            KappaGCNLayer(in_features=dim, out_features=dim, manifold=self.manifold),
+        self.ff1 = KappaGCNLayer(
+            in_features=dim,
+            out_features=dim,
+            manifold=manifold,
+            nonlinearity=torch.relu,
         )
+        self.ff2 = KappaGCNLayer(in_features=dim, out_features=dim, manifold=manifold, nonlinearity=None)
+
+    def _mlpblock(self, X: Float[torch.Tensor, "n_nodes dim"]) -> Float[torch.Tensor, "n_nodes dim"]:
+        """Two-layer manifold feedforward network."""
+        return self.ff2(self.ff1(X))
 
     def forward(
         self,
         X: Float[torch.Tensor, "n_nodes dim"],
         mask: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
     ) -> Float[torch.Tensor, "n_nodes dim"]:
-        """Forward pass through the stereographic transformer block."""
-        X = geoopt.manifolds.stereographic.math.mobius_add(self.mha(self.norm1(X), mask), X, self.curvatures)
-        X = geoopt.manifolds.stereographic.math.project(X, self.curvatures)
-        X = geoopt.manifolds.stereographic.math.mobius_add(self.mlpblock(self.norm2(X)), X, self.curvatures)
-        X = geoopt.manifolds.stereographic.math.project(X, self.curvatures)
+        """Forward pass through the stereographic transformer block.
+
+        Args:
+            X: Node features as points on the manifold, shape ``[n_nodes, dim]``.
+            mask: Optional adjacency matrix ``A_hat``; ``None`` means full attention.
+
+        Returns:
+            Updated node features as points on the manifold, shape ``[n_nodes, dim]``.
+        """
+        man = self.manifold.manifold
+
+        # Pre-norm attention sublayer with Mobius-addition residual.
+        attn = self.mha(self.norm1(X), mask)
+        X = man.projx(man.mobius_add(attn, X))
+
+        # Pre-norm feedforward sublayer with Mobius-addition residual.
+        ff = self._mlpblock(self.norm2(X))
+        X = man.projx(man.mobius_add(ff, X))
 
         return X
-
-
-def _reshape_curvatures(curvatures: float | list[float], num_heads: int) -> Float[torch.Tensor, "num_heads 1 1"]:
-    """Helper function to reshape curvature(s) for use in multi-head stereographic attention."""
-    if isinstance(curvatures, float):
-        output_curvatures = torch.tensor([curvatures] * num_heads, dtype=torch.float)
-    else:
-        output_curvatures = torch.tensor(curvatures, dtype=torch.float)
-    return output_curvatures[:, None, None]
-
-
-def _get_curvatures(manifold: Manifold | ProductManifold) -> float | list[float]:
-    """Helper function to retrieve curvature(s) from a Manifold or ProductManifold."""
-    if isinstance(manifold, ProductManifold):
-        return manifold.curvatures
-    elif isinstance(manifold, Manifold):
-        return manifold.curvature
-    else:
-        raise TypeError("Expected a Manifold or ProductManifold class.")

--- a/manify/predictors/nn/layers.py
+++ b/manify/predictors/nn/layers.py
@@ -31,11 +31,7 @@ class KappaGCNLayer(torch.nn.Module):
     """
 
     def __init__(
-        self,
-        in_features: int,
-        out_features: int,
-        manifold: Manifold,
-        nonlinearity: Callable | None = torch.relu,
+        self, in_features: int, out_features: int, manifold: Manifold, nonlinearity: Callable | None = torch.relu
     ):
         super().__init__()
 
@@ -49,10 +45,7 @@ class KappaGCNLayer(torch.nn.Module):
         self.manifold = manifold
 
     def _left_multiply(
-        self,
-        A: Float[torch.Tensor, "n_nodes n_nodes"],
-        X: Float[torch.Tensor, "n_nodes dim"],
-        M: Manifold,
+        self, A: Float[torch.Tensor, "n_nodes n_nodes"], X: Float[torch.Tensor, "n_nodes dim"], M: Manifold
     ) -> Float[torch.Tensor, "n_nodes dim"]:
         r"""$\kappa$-left matrix multiply two matrices $\mathbf{A}$ and $\mathbf{X}$.
 
@@ -78,9 +71,7 @@ class KappaGCNLayer(torch.nn.Module):
         )
 
     def forward(
-        self,
-        X: Float[torch.Tensor, "n_nodes dim"],
-        A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
+        self, X: Float[torch.Tensor, "n_nodes dim"], A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None
     ) -> Float[torch.Tensor, "n_nodes dim"]:
         """Forward pass for the Kappa GCN layer.
 
@@ -125,9 +116,7 @@ class KappaSequential(nn.Module):
         self.layers = nn.ModuleList(layers)
 
     def forward(
-        self,
-        X: Float[torch.Tensor, "n_nodes dim"],
-        A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
+        self, X: Float[torch.Tensor, "n_nodes dim"], A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None
     ) -> Float[torch.Tensor, "n_nodes out_dim"]:
         """Forward pass through all layers.
 
@@ -178,12 +167,7 @@ class StereographicLogits(nn.Module):
         apply_softmax: Whether to apply softmax to the output logits (default: False)
     """
 
-    def __init__(
-        self,
-        out_features: int,
-        manifold: Manifold | ProductManifold,
-        apply_softmax: bool = False,
-    ):
+    def __init__(self, out_features: int, manifold: Manifold | ProductManifold, apply_softmax: bool = False):
         super().__init__()
 
         self.out_features = out_features
@@ -204,10 +188,7 @@ class StereographicLogits(nn.Module):
         M: Manifold,
         return_inner_products: bool = False,
     ) -> (
-        tuple[
-            Float[torch.Tensor, "n_nodes n_classes"],
-            Float[torch.Tensor, "n_nodes n_classes"],
-        ]
+        tuple[Float[torch.Tensor, "n_nodes n_classes"], Float[torch.Tensor, "n_nodes n_classes"]]
         | Float[torch.Tensor, "n_nodes n_classes"]
     ):
         """Compute logits for a single manifold."""
@@ -337,9 +318,7 @@ class FermiDiracDecoder(nn.Module):
             self.register_buffer("bias", torch.tensor(0.0))
 
     def forward(
-        self,
-        X: Float[torch.Tensor, "n_nodes dim"],
-        A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
+        self, X: Float[torch.Tensor, "n_nodes dim"], A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None
     ) -> Float[torch.Tensor, "n_nodes n_nodes"]:
         """Forward pass through Fermi-Dirac decoder.
 
@@ -529,13 +508,7 @@ class StereographicAttention(nn.Module):
         restriction while remaining curvature-correct via ``logmap0``/``expmap0``.
     """
 
-    def __init__(
-        self,
-        manifold: Manifold | ProductManifold,
-        num_heads: int,
-        dim: int,
-        head_dim: int,
-    ):
+    def __init__(self, manifold: Manifold | ProductManifold, num_heads: int, dim: int, head_dim: int):
         super().__init__()
 
         self.manifold = manifold
@@ -552,9 +525,7 @@ class StereographicAttention(nn.Module):
         self.attn = GeometricLinearizedAttention(num_heads=num_heads, head_dim=head_dim)
 
     def forward(
-        self,
-        X: Float[torch.Tensor, "n_nodes dim"],
-        mask: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
+        self, X: Float[torch.Tensor, "n_nodes dim"], mask: Float[torch.Tensor, "n_nodes n_nodes"] | None = None
     ) -> Float[torch.Tensor, "n_nodes dim"]:
         """Forward pass for the stereographic attention layer."""
         # Move to the tangent space at the origin; attention is Euclidean there.
@@ -612,12 +583,7 @@ class StereographicTransformer(nn.Module):
     """
 
     def __init__(
-        self,
-        manifold: Manifold | ProductManifold,
-        num_heads: int,
-        dim: int,
-        head_dim: int,
-        use_layer_norm: bool = True,
+        self, manifold: Manifold | ProductManifold, num_heads: int, dim: int, head_dim: int, use_layer_norm: bool = True
     ):
         super().__init__()
 
@@ -637,12 +603,7 @@ class StereographicTransformer(nn.Module):
             self.norm1 = nn.Identity()
             self.norm2 = nn.Identity()
 
-        self.ff1 = KappaGCNLayer(
-            in_features=dim,
-            out_features=dim,
-            manifold=manifold,
-            nonlinearity=torch.relu,
-        )
+        self.ff1 = KappaGCNLayer(in_features=dim, out_features=dim, manifold=manifold, nonlinearity=torch.relu)
         self.ff2 = KappaGCNLayer(in_features=dim, out_features=dim, manifold=manifold, nonlinearity=None)
 
     def _mlpblock(self, X: Float[torch.Tensor, "n_nodes dim"]) -> Float[torch.Tensor, "n_nodes dim"]:
@@ -650,9 +611,7 @@ class StereographicTransformer(nn.Module):
         return self.ff2(self.ff1(X))
 
     def forward(
-        self,
-        X: Float[torch.Tensor, "n_nodes dim"],
-        mask: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
+        self, X: Float[torch.Tensor, "n_nodes dim"], mask: Float[torch.Tensor, "n_nodes n_nodes"] | None = None
     ) -> Float[torch.Tensor, "n_nodes dim"]:
         """Forward pass through the stereographic transformer block.
 

--- a/manify/predictors/nn/layers.py
+++ b/manify/predictors/nn/layers.py
@@ -607,8 +607,8 @@ class StereographicTransformer(nn.Module):
         mha: Multi-head stereographic attention module.
         norm1: First normalization layer (Identity or StereographicLayerNorm).
         norm2: Second normalization layer (Identity or StereographicLayerNorm).
-        mlpblock: Feedforward network operating on the manifold.
-        stereographic_activation: Activation wrapped to operate in tangent space.
+        ff1: First feedforward KappaGCNLayer (with ReLU nonlinearity).
+        ff2: Second feedforward KappaGCNLayer (no nonlinearity).
     """
 
     def __init__(
@@ -628,7 +628,6 @@ class StereographicTransformer(nn.Module):
             )
 
         self.manifold = manifold
-        self.stereographic_activation = manifold.apply(nn.ReLU())
         self.mha = StereographicAttention(manifold=manifold, num_heads=num_heads, dim=dim, head_dim=head_dim)
 
         if use_layer_norm:

--- a/manify/predictors/nn/layers.py
+++ b/manify/predictors/nn/layers.py
@@ -397,25 +397,34 @@ class StereographicLayerNorm(nn.Module):
 
 
 class GeometricLinearizedAttention(nn.Module):
-    r"""Linear (kernelized) multi-head attention in the tangent space of a stereographic manifold.
+    r"""Faithful gyrovector linear attention (FPS-T, arXiv:2309.04082, Eqs 6, 7, 11).
 
-    The semantics deliberately follow the rest of ``manify``: a *single graph* of ``n_nodes`` tokens
-    with shape ``[n_nodes, dim]`` (no batch dimension), exactly like :class:`KappaGCNLayer`. The
-    ``mask`` plays the role of the (normalized) adjacency matrix ``A_hat`` -- an all-ones mask gives
-    full self-attention, a sparse mask restricts which tokens may attend to which.
+    This is the kernelized mixed-curvature attention from "Curve Your Attention: Mixed-Curvature
+    Transformers for Graph Representation Learning". It operates per head on its own
+    :math:`\kappa_h`-stereographic space. Following the rest of ``manify`` it works on a *single
+    graph* (no batch dimension): inputs are ``[num_heads, n_nodes, head_dim]`` and the ``mask`` is the
+    ``[n_nodes, n_nodes]`` adjacency matrix (``None`` means full attention).
 
-    Attention itself is computed in the tangent space at the origin, where the geometry is Euclidean
-    and standard linear attention with the ``elu(x) + 1`` feature map is well defined. The caller is
-    responsible for mapping points on/off the manifold (this module receives and returns *tangent*
-    vectors). Working in the tangent space sidesteps the ill-posed problem of slicing a product
-    manifold's coordinates across heads and yields an exact Euclidean limit as curvature -> 0.
+    Inputs:
+        * ``V`` -- value *points* on the per-head :math:`\kappa_h`-stereographic manifold.
+        * ``Q``, ``K`` -- query/key *tangent vectors at the corresponding* ``V_i`` (Eq 5).
 
-    Linear attention computes, per query ``i``:
+    Scores (Eq 6): parallel-transport ``Q_i`` and ``K_j`` to the origin (``parallel_transport0back``),
+    apply the feature map :math:`\phi(x)=\mathrm{ELU}(x)+1`, and take a Euclidean inner product there:
+    :math:`\alpha_{ij}\approx\phi(\tilde Q_i)^\top\phi(\tilde K_j)`.
 
-    $$ \mathrm{out}_i = \frac{\sum_j m_{ij}\, \phi(q_i)^\top \phi(k_j)\, v_j}
-                              {\sum_j m_{ij}\, \phi(q_i)^\top \phi(k_j)}, \qquad \phi(x) = elu(x) + 1 $$
+    Aggregation (Eq 7) is the **Einstein midpoint**, kernelized (Eq 11):
 
-    which is evaluated in the kernel-factorized (linear-time) form.
+    $$ \mathrm{Aggregate}_\kappa(V,\alpha)_i = \tfrac{1}{2}\otimes_\kappa
+        \sum_j \frac{\alpha_{ij}\,\lambda^\kappa_{V_j}}
+                    {\sum_k \alpha_{ik}(\lambda^\kappa_{V_k}-1)}\, V_j, $$
+
+    where :math:`\lambda^\kappa` is the conformal factor and :math:`\tfrac12\otimes_\kappa` is Mobius
+    scalar multiplication. Writing :math:`\tilde V_i=\frac{\lambda^\kappa_{V_i}}{\lambda^\kappa_{V_i}-1}V_i`
+    and :math:`\phi'(\tilde K)_i=\phi(\tilde K_i)(\lambda^\kappa_{V_i}-1)`, the per-query output is
+    :math:`\tfrac12\otimes_\kappa\big[\phi(\tilde Q)\,(\phi'(\tilde K)^\top \tilde V)\big]_i`, which is
+    :math:`O(N+M)` in the full-attention case. As :math:`\kappa\to0` the Einstein midpoint reduces to
+    the ordinary (Euclidean) weighted mean.
 
     Args:
         num_heads: Number of attention heads.
@@ -432,83 +441,117 @@ class GeometricLinearizedAttention(nn.Module):
         self.num_heads = num_heads
         self.head_dim = head_dim
         self._epsilon = 1e-6
+        self._clamp_epsilon = 1e-10
 
     def forward(
         self,
         Q: Float[torch.Tensor, "num_heads n_nodes head_dim"],
         K: Float[torch.Tensor, "num_heads n_nodes head_dim"],
         V: Float[torch.Tensor, "num_heads n_nodes head_dim"],
+        curvatures: Float[torch.Tensor, "num_heads 1 1"],
         mask: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
     ) -> Float[torch.Tensor, "num_heads n_nodes head_dim"]:
-        """Forward pass for tangent-space linear attention.
+        """Forward pass for faithful gyrovector linear attention.
 
         Args:
-            Q: Query tensor, shape ``[num_heads, n_nodes, head_dim]``.
-            K: Key tensor, shape ``[num_heads, n_nodes, head_dim]``.
-            V: Value tensor, shape ``[num_heads, n_nodes, head_dim]``.
+            Q: Query tangent vectors at ``V``, shape ``[num_heads, n_nodes, head_dim]``.
+            K: Key tangent vectors at ``V``, shape ``[num_heads, n_nodes, head_dim]``.
+            V: Value points on the per-head manifold, shape ``[num_heads, n_nodes, head_dim]``.
+            curvatures: Per-head curvatures, shape ``[num_heads, 1, 1]``.
             mask: Optional adjacency/attention mask, shape ``[n_nodes, n_nodes]``. Entry ``(i, j)``
                 weights how much query ``i`` attends to key/value ``j``. ``None`` means full attention.
 
         Returns:
-            Output tensor, shape ``[num_heads, n_nodes, head_dim]``.
+            Aggregated value points on the per-head manifold, shape ``[num_heads, n_nodes, head_dim]``.
         """
-        # Feature map phi(x) = elu(x) + 1 > 0, so attention weights are non-negative.
-        Qf = nn.functional.elu(Q) + 1.0  # [H, N, d]
-        Kf = nn.functional.elu(K) + 1.0  # [H, N, d]
+        k = curvatures
+        math = geoopt.manifolds.stereographic.math
+
+        # Eq 6: parallel-transport Q, K (tangent at V) to the origin, then feature map phi = elu + 1.
+        q_tilde = math.parallel_transport0back(V, Q, k=k)  # [H, N, d]
+        k_tilde = math.parallel_transport0back(V, K, k=k)  # [H, N, d]
+        phi_q = nn.functional.elu(q_tilde) + 1.0  # phi(Q~)
+        phi_k = nn.functional.elu(k_tilde) + 1.0  # phi(K~)
+
+        # Conformal factor lambda^kappa at each value point (Eq 7).
+        lam = math.lambda_x(x=V, k=k, keepdim=True, dim=-1)  # [H, N, 1]
+        denom = geoopt.utils.clamp_abs(lam - 1, self._clamp_epsilon)  # (lambda - 1), [H, N, 1]
+
+        v_tilde = (lam / denom) * V  # V~_i = lambda_i / (lambda_i - 1) * V_i
+        phi_k_prime = denom * phi_k  # phi'(K~)_i = phi(K~)_i * (lambda_i - 1)
 
         if mask is None:
-            # Linear-time form: aggregate over keys first, O(N d^2) instead of O(N^2 d).
-            kv = torch.einsum("hnd,hne->hde", Kf, V)  # [H, d, d]
-            numerator = torch.einsum("hnd,hde->hne", Qf, kv)  # [H, N, d]
-            k_sum = Kf.sum(dim=1)  # [H, d]
-            denominator = torch.einsum("hnd,hd->hn", Qf, k_sum)  # [H, N]
+            # Kernelized O(N + M) form (Eq 11). The numerator effectively weights V_j by
+            # alpha_ij * lambda_j = (phi(Q~)_i . phi'(K~)_j) * V~_j, and the normalizer by
+            # alpha_ij * (lambda_j - 1) = phi(Q~)_i . phi'(K~)_j.
+            context = torch.einsum("hnd,hne->hde", phi_k_prime, v_tilde)  # phi'(K)^T V~, [H, d, d]
+            numerator = torch.einsum("hnd,hde->hne", phi_q, context)  # [H, N, d]
+            normalizer = torch.einsum("hnd,hd->hn", phi_q, phi_k_prime.sum(dim=-2))  # [H, N]
         else:
-            # Masked form: explicit (masked) attention scores. O(N^2 d) but supports adjacency.
-            scores = torch.einsum("hnd,hmd->hnm", Qf, Kf)  # [H, N, N]
-            scores = scores * mask[None]  # broadcast mask over heads
-            numerator = torch.einsum("hnm,hme->hne", scores, V)  # [H, N, d]
-            denominator = scores.sum(dim=-1)  # [H, N]
+            # Explicit (masked) attention scores -- supports a sparse adjacency, O(N^2 d).
+            # Identical math to the kernelized path: numerator weights V_j by alpha_ij * lambda_j,
+            # normalizer by alpha_ij * (lambda_j - 1).
+            alpha = torch.einsum("hnd,hmd->hnm", phi_q, phi_k) * mask[None]  # [H, N, N]
+            numerator = torch.einsum("hnm,hme->hne", alpha, lam * V)  # [H, N, d]
+            normalizer = torch.einsum("hnm,hm->hn", alpha, denom.squeeze(-1))  # [H, N]
 
-        denominator = denominator.clamp_min(self._epsilon).unsqueeze(-1)  # [H, N, 1]
-        return numerator / denominator
+        norm_inv = 1.0 / normalizer.masked_fill(normalizer == 0, self._epsilon)  # [H, N]
+        midpoint = numerator * norm_inv.unsqueeze(-1)  # weighted gyro-sum, [H, N, d]
+
+        # Einstein midpoint finishes with a Mobius half-scaling; project for numerical safety.
+        out = math.project(midpoint, k=k)
+        out = math.mobius_scalar_mul(torch.tensor(0.5, dtype=out.dtype, device=out.device), out, k=k, dim=-1)
+        out = math.project(out, k=k)
+        return out
 
 
 class StereographicAttention(nn.Module):
-    """Stereographic multi-head attention layer for a single graph of ``[n_nodes, dim]`` tokens.
+    r"""Mixed-curvature multi-head attention for a single graph of ``[n_nodes, dim]`` tokens (FPS-T).
 
-    Inputs and outputs are points on a stereographic (product) manifold. Queries, keys and values are
-    produced by Mobius matrix-vector products (queries/keys) and a :class:`KappaGCNLayer` (values),
-    then attention is performed in the tangent space at the origin by
-    :class:`GeometricLinearizedAttention`, and the result is mapped back onto the manifold by a
-    :class:`KappaGCNLayer` output projection. The ``mask`` is the adjacency matrix ``A_hat`` (or
-    ``None`` for full attention).
+    Faithful implementation of the multi-head attention from "Curve Your Attention" (arXiv:2309.04082).
+    Each head ``h`` operates on its OWN :math:`\kappa_h`-stereographic space with an independent
+    **learnable** curvature, and the multi-head output is the *product* over heads
+    (:math:`\bigotimes_h \mathrm{st}_{\kappa_h}`) -- heads are product-manifold components, so per-head
+    outputs are concatenated and never reshaped across heads. The per-head curvatures are decoupled
+    from the input manifold.
+
+    Per head (Eq 5): values are points on :math:`\mathrm{st}_{\kappa_h}` and queries/keys live in the
+    tangent space at the corresponding value point. We obtain these by mapping the input to the tangent
+    space at the origin (``logmap0``), applying an ordinary Euclidean ``nn.Linear`` to the head
+    dimension, and exponentiating into :math:`\mathrm{st}_{\kappa_h}` for the values; queries/keys are
+    the (Euclidean) projections re-based to the tangent space at each value point via parallel
+    transport from the origin. Aggregation is the gyrovector Einstein midpoint
+    (:class:`GeometricLinearizedAttention`). The masked output product manifold is mapped back to the
+    input manifold by a tangent-space linear projection (``logmap0`` -> ``Linear`` -> ``expmap0``).
 
     Args:
-        manifold: Stereographic Manifold or ProductManifold defining the geometry.
-        num_heads: Number of attention heads.
+        manifold: Stereographic Manifold or ProductManifold defining the input/output geometry.
+        num_heads: Number of attention heads (product-manifold components).
         dim: Embedding dimension of the input/output points (``manifold.dim``).
         head_dim: Dimension of each attention head.
+        init_curvatures: Optional list of initial per-head curvatures (length ``num_heads``). Defaults
+            to ``-1`` for the first half of heads and ``+1`` for the rest (mixed curvature).
 
     Attributes:
-        manifold: The manifold object for geometric operations.
+        manifold: The (input/output) manifold object.
         num_heads: Number of attention heads.
         head_dim: Dimensionality of each attention head.
+        curvatures: Learnable per-head curvatures, shape ``[num_heads]``.
         W_q: Euclidean (tangent-space) linear projection to query vectors.
         W_k: Euclidean (tangent-space) linear projection to key vectors.
         W_v: Euclidean (tangent-space) linear projection to value vectors.
-        attn: Tangent-space linear attention module.
+        attn: Gyrovector Einstein-midpoint attention module.
         W_o: Euclidean (tangent-space) linear output projection.
-
-    Note:
-        Queries/keys/values are computed by ordinary Euclidean linear maps *in the tangent space at
-        the origin* rather than by Mobius matrix-vector products. This is deliberate: on a product
-        stereographic manifold, ``mobius_matvec`` is applied per component and therefore cannot change
-        the per-component dimensionality, so it could not realize an arbitrary ``num_heads * head_dim``
-        projection. Operating in the tangent space (where the geometry is Euclidean) removes that
-        restriction while remaining curvature-correct via ``logmap0``/``expmap0``.
     """
 
-    def __init__(self, manifold: Manifold | ProductManifold, num_heads: int, dim: int, head_dim: int):
+    def __init__(
+        self,
+        manifold: Manifold | ProductManifold,
+        num_heads: int,
+        dim: int,
+        head_dim: int,
+        init_curvatures: list[float] | None = None,
+    ):
         super().__init__()
 
         self.manifold = manifold
@@ -516,7 +559,12 @@ class StereographicAttention(nn.Module):
         self.head_dim = head_dim
         inner = num_heads * head_dim
 
-        # Linear maps live in the tangent space at the origin (Euclidean), so dimension changes are fine.
+        # Learnable per-head curvatures (decoupled from the input manifold). Default: mixed curvature.
+        if init_curvatures is None:
+            init_curvatures = [-1.0] * (num_heads // 2) + [1.0] * (num_heads - num_heads // 2)
+        self.curvatures = nn.Parameter(torch.tensor(init_curvatures, dtype=torch.float))
+
+        # Tangent-space linear projections (paper-faithful; allow free head_dim).
         self.W_q = nn.Linear(dim, inner)
         self.W_k = nn.Linear(dim, inner)
         self.W_v = nn.Linear(dim, inner)
@@ -524,23 +572,34 @@ class StereographicAttention(nn.Module):
 
         self.attn = GeometricLinearizedAttention(num_heads=num_heads, head_dim=head_dim)
 
+    def _per_head_curvatures(self) -> Float[torch.Tensor, "num_heads 1 1"]:
+        """Reshape the learnable per-head curvatures for broadcasting over ``[H, N, d]``."""
+        return self.curvatures.view(self.num_heads, 1, 1)
+
     def forward(
         self, X: Float[torch.Tensor, "n_nodes dim"], mask: Float[torch.Tensor, "n_nodes n_nodes"] | None = None
     ) -> Float[torch.Tensor, "n_nodes dim"]:
-        """Forward pass for the stereographic attention layer."""
-        # Move to the tangent space at the origin; attention is Euclidean there.
+        """Forward pass for the mixed-curvature attention layer."""
+        math = geoopt.manifolds.stereographic.math
+        k = self._per_head_curvatures()  # [H, 1, 1]
+
+        # Tangent space at the origin of the input manifold, then per-head Euclidean projections.
         H = self.manifold.manifold.logmap0(X)  # [N, dim]
+        q_tan = self._split_heads(self.W_q(H))  # [H, N, d] (Euclidean, at origin)
+        k_tan = self._split_heads(self.W_k(H))
+        v_tan = self._split_heads(self.W_v(H))
 
-        Q = self._split_heads(self.W_q(H))  # [H, N, head_dim]
-        K = self._split_heads(self.W_k(H))
-        V = self._split_heads(self.W_v(H))
+        # Values are points on the per-head st_{kappa_h}; Q/K are tangent vectors AT each value point.
+        V = math.expmap0(v_tan, k=k)  # [H, N, d] points on st_kappa_h
+        Q = math.parallel_transport0(V, q_tan, k=k)  # tangent at V_i (Eq 5)
+        K = math.parallel_transport0(V, k_tan, k=k)
 
-        attn_out = self.attn(Q, K, V, mask)  # [H, N, head_dim]
-        attn_out = self._combine_heads(attn_out)  # [N, inner]
-        attn_out = self.W_o(attn_out)  # [N, dim]
+        attn_out = self.attn(Q, K, V, curvatures=k, mask=mask)  # [H, N, d] points on st_kappa_h
 
-        # Back onto the manifold.
-        return self.manifold.manifold.expmap0(attn_out)
+        # Multi-head output is the product over heads: concat per-head tangent coords, project back.
+        attn_tan = self._combine_heads(math.logmap0(attn_out, k=k))  # [N, inner] (tangent)
+        out_tan = self.W_o(attn_tan)  # [N, dim]
+        return self.manifold.manifold.expmap0(out_tan)
 
     def _combine_heads(
         self, X: Float[torch.Tensor, "num_heads n_nodes head_dim"]
@@ -558,13 +617,15 @@ class StereographicAttention(nn.Module):
 
 
 class StereographicTransformer(nn.Module):
-    """Stereographic Transformer block operating on a single graph of ``[n_nodes, dim]`` tokens.
+    r"""Mixed-curvature transformer block on a single graph of ``[n_nodes, dim]`` tokens (FPS-T).
 
-    A pre-norm transformer block adapted to a stereographic (product) manifold: each sublayer maps
-    points to the tangent space at the origin where the computation is Euclidean, and back onto the
-    manifold, with Mobius-addition residual connections. Tokens are graph nodes; the ``mask`` is the
-    adjacency matrix ``A_hat`` (``None`` for full attention). In the curvature-zero limit the block
-    reduces to a standard Euclidean linear-attention transformer block.
+    A pre-norm transformer block adapted to a stereographic (product) manifold per "Curve Your
+    Attention" (arXiv:2309.04082): a mixed-curvature multi-head attention sublayer
+    (:class:`StereographicAttention`, faithful gyrovector Einstein-midpoint aggregation with learnable
+    per-head curvatures) followed by a manifold feedforward sublayer, each wrapped in a Mobius-addition
+    residual connection. Tokens are graph nodes; the ``mask`` is the adjacency matrix ``A_hat``
+    (``None`` for full attention). As the curvatures vanish the block reduces to a standard Euclidean
+    linear-attention transformer block.
 
     Args:
         manifold: Stereographic Manifold or ProductManifold defining the geometry.
@@ -572,10 +633,11 @@ class StereographicTransformer(nn.Module):
         dim: Dimensionality of the input features (``manifold.dim``).
         head_dim: Dimensionality of each attention head.
         use_layer_norm: Whether to apply (tangent-space) layer normalization.
+        init_curvatures: Optional initial per-head curvatures passed to the attention sublayer.
 
     Attributes:
         manifold: The manifold object for geometric operations.
-        mha: Multi-head stereographic attention module.
+        mha: Mixed-curvature multi-head attention module.
         norm1: First normalization layer (Identity or StereographicLayerNorm).
         norm2: Second normalization layer (Identity or StereographicLayerNorm).
         ff1: First feedforward KappaGCNLayer (with ReLU nonlinearity).
@@ -583,7 +645,13 @@ class StereographicTransformer(nn.Module):
     """
 
     def __init__(
-        self, manifold: Manifold | ProductManifold, num_heads: int, dim: int, head_dim: int, use_layer_norm: bool = True
+        self,
+        manifold: Manifold | ProductManifold,
+        num_heads: int,
+        dim: int,
+        head_dim: int,
+        use_layer_norm: bool = True,
+        init_curvatures: list[float] | None = None,
     ):
         super().__init__()
 
@@ -594,7 +662,9 @@ class StereographicTransformer(nn.Module):
             )
 
         self.manifold = manifold
-        self.mha = StereographicAttention(manifold=manifold, num_heads=num_heads, dim=dim, head_dim=head_dim)
+        self.mha = StereographicAttention(
+            manifold=manifold, num_heads=num_heads, dim=dim, head_dim=head_dim, init_curvatures=init_curvatures
+        )
 
         if use_layer_norm:
             self.norm1: nn.Module = StereographicLayerNorm(manifold=manifold, embedding_dim=dim)
@@ -613,7 +683,7 @@ class StereographicTransformer(nn.Module):
     def forward(
         self, X: Float[torch.Tensor, "n_nodes dim"], mask: Float[torch.Tensor, "n_nodes n_nodes"] | None = None
     ) -> Float[torch.Tensor, "n_nodes dim"]:
-        """Forward pass through the stereographic transformer block.
+        """Forward pass through the mixed-curvature transformer block.
 
         Args:
             X: Node features as points on the manifold, shape ``[n_nodes, dim]``.

--- a/manify/predictors/transformer.py
+++ b/manify/predictors/transformer.py
@@ -1,0 +1,253 @@
+r"""Stereographic (product-manifold) transformer predictor.
+
+`KappaTransformer` is a transductive, single-graph node classifier/regressor built from a stack of
+:class:`~manify.predictors.nn.layers.StereographicTransformer` blocks followed by a
+:class:`~manify.predictors.nn.layers.StereographicLogits` head. It mirrors
+:class:`~manify.predictors.kappa_gcn.KappaGCN`: it operates on a single graph of ``[n_nodes, dim]``
+points on a stereographic ``ProductManifold`` (no batch dimension), and implements the
+``BasePredictor`` ``fit`` / ``predict`` / ``predict_proba`` API.
+
+The optional adjacency matrix ``A`` is normalized to ``A_hat`` (via
+:func:`~manify.predictors.kappa_gcn.get_A_hat`) and used as the attention mask inside every block:
+``A`` therefore restricts which nodes may attend to which. If ``A`` is ``None`` the transformer uses
+full (all-to-all) self-attention, i.e. an attention-based set encoder over the nodes.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import geoopt
+import torch
+
+if TYPE_CHECKING:
+    from beartype.typing import Literal
+    from jaxtyping import Float, Real
+
+from ..manifolds import ProductManifold
+from ._base import BasePredictor
+from .kappa_gcn import get_A_hat
+from .nn import StereographicLogits, StereographicTransformer
+
+# TQDM: notebook or regular
+if "ipykernel" in sys.modules:
+    from tqdm.notebook import tqdm
+else:
+    from tqdm import tqdm
+
+
+class KappaTransformer(BasePredictor, torch.nn.Module):
+    r"""Stereographic product-manifold transformer for node classification/regression.
+
+    Stacks ``num_layers`` stereographic transformer blocks over a single graph of ``[n_nodes, dim]``
+    points on a stereographic ``ProductManifold``, then applies a stereographic logits head. The
+    adjacency matrix (if provided) is used as the attention mask in every block.
+
+    Args:
+        pm: Stereographic ProductManifold defining the geometry.
+        output_dim: Number of output features (classes for classification, target dim for regression).
+        num_layers: Number of stereographic transformer blocks.
+        num_heads: Number of attention heads per block.
+        head_dim: Dimension of each attention head. Defaults to ``max(1, pm.dim // num_heads)``.
+        use_layer_norm: Whether to use (tangent-space) layer normalization in each block.
+        task: Task type, one of ["classification", "regression"].
+        random_state: Random seed for reproducibility.
+        device: Device to run the model on (default: None, uses ``pm.device``).
+
+    Attributes:
+        pm: The stereographic ProductManifold.
+        blocks: ``torch.nn.ModuleList`` of stereographic transformer blocks.
+        output_layer: Stereographic logits head.
+        is_fitted_: Whether the model has been fitted.
+        loss_history_: History of loss values during training.
+
+    Raises:
+        ValueError: If the ProductManifold is not stereographic, or task is unsupported.
+    """
+
+    def __init__(
+        self,
+        pm: ProductManifold,
+        output_dim: int,
+        num_layers: int = 2,
+        num_heads: int = 2,
+        head_dim: int | None = None,
+        use_layer_norm: bool = True,
+        task: Literal["classification", "regression"] = "classification",
+        random_state: int | None = None,
+        device: str | None = None,
+    ):
+        BasePredictor.__init__(self, pm=pm, task=task, random_state=random_state, device=device)
+        torch.nn.Module.__init__(self)
+
+        if not pm.is_stereographic:
+            raise ValueError(
+                "ProductManifold must be stereographic for KappaTransformer to work. "
+                "Please use pm.stereographic() to convert."
+            )
+        if task not in ("classification", "regression"):
+            raise ValueError(f"KappaTransformer supports 'classification' and 'regression', got {task!r}.")
+
+        if random_state is not None:
+            torch.manual_seed(random_state)
+
+        self.pm = pm
+        self.task = task
+        self.output_dim = output_dim
+        self.num_layers = num_layers
+        self.num_heads = num_heads
+        self.head_dim = head_dim if head_dim is not None else max(1, pm.dim // num_heads)
+        self.use_layer_norm = use_layer_norm
+
+        self.blocks = torch.nn.ModuleList(
+            [
+                StereographicTransformer(
+                    manifold=pm,
+                    num_heads=num_heads,
+                    dim=pm.dim,
+                    head_dim=self.head_dim,
+                    use_layer_norm=use_layer_norm,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
+        # Softmax is applied in the loss (classification) / not at all (regression), so keep it off here.
+        self.output_layer = StereographicLogits(output_dim, pm, apply_softmax=False)
+
+    def forward(
+        self,
+        X: Float[torch.Tensor, "n_nodes dim"],
+        A_hat: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
+        softmax: bool = False,
+    ) -> Float[torch.Tensor, "n_nodes n_classes"] | Float[torch.Tensor, "n_nodes"]:
+        """Forward pass through the transformer blocks and logits head.
+
+        Args:
+            X: Node features as points on the manifold, shape ``[n_nodes, dim]``.
+            A_hat: Optional normalized adjacency matrix used as the attention mask. ``None`` means
+                full attention.
+            softmax: Whether to apply softmax to the output logits.
+
+        Returns:
+            Logits/values of shape ``[n_nodes, n_classes]`` (squeezed for regression).
+        """
+        H = X
+        for block in self.blocks:
+            H = block(H, A_hat)
+
+        # Aggregate logits along edges only when an adjacency is provided (matches KappaGCN behavior).
+        logits = self.output_layer(H, A_hat, aggregate_logits=A_hat is not None)
+
+        if softmax:
+            logits = torch.softmax(logits, dim=-1)
+
+        return logits.squeeze()
+
+    def fit(
+        self,
+        X: Float[torch.Tensor, "n_nodes dim"],
+        y: Real[torch.Tensor, "n_nodes"],
+        A: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
+        epochs: int = 2_000,
+        lr: float = 1e-2,
+        use_tqdm: bool = True,
+        tqdm_prefix: str | None = None,
+    ) -> KappaTransformer:
+        """Fit the KappaTransformer model.
+
+        Args:
+            X: Feature matrix of points on the manifold, shape ``[n_nodes, dim]``.
+            y: Labels for the nodes.
+            A: Optional adjacency or distance matrix; normalized to ``A_hat`` and used as the
+                attention mask. If ``None``, full attention is used.
+            epochs: Number of training epochs.
+            lr: Learning rate.
+            use_tqdm: Whether to show a tqdm progress bar.
+            tqdm_prefix: Prefix for the tqdm progress bar.
+
+        Returns:
+            self: The fitted predictor.
+        """
+        X = X.clone()
+        y = y.clone()
+        A = A.clone() if A is not None else None
+        A_hat = get_A_hat(A, make_symmetric=True, add_self_loops=True) if A is not None else None
+
+        # Euclidean parameters (everything except the manifold-valued bias points of the head).
+        euclidean_params = [p for n, p in self.named_parameters() if not isinstance(p, geoopt.ManifoldParameter)]
+        riemannian_params = [self.output_layer.p_ks]
+
+        opt = torch.optim.Adam(euclidean_params, lr=lr)
+        ropt = geoopt.optim.RiemannianAdam(riemannian_params, lr=lr)
+
+        if self.task == "classification":
+            loss_fn = torch.nn.CrossEntropyLoss()
+            y = y.long()
+        else:  # regression
+            loss_fn = torch.nn.MSELoss()
+            y = y.float()
+
+        self.train()
+        my_tqdm = tqdm(total=epochs, desc=tqdm_prefix) if use_tqdm else None
+
+        losses = []
+        for i in range(epochs):
+            opt.zero_grad()
+            ropt.zero_grad()
+            y_pred = self(X, A_hat)
+            loss = loss_fn(y_pred, y)
+            loss.backward()
+            opt.step()
+            ropt.step()
+
+            if my_tqdm is not None:
+                my_tqdm.update(1)
+                my_tqdm.set_description(f"Epoch {i + 1}/{epochs}, Loss: {loss.item():.4f}")
+
+            if torch.isnan(loss):
+                print("Loss is NaN, stopping training.")
+                break
+            losses.append(loss.item())
+
+        if my_tqdm is not None:
+            my_tqdm.close()
+
+        self.is_fitted_ = True
+        self.loss_history_["train"] = losses
+        return self
+
+    def predict_proba(
+        self,
+        X: Float[torch.Tensor, "n_nodes dim"],
+        A: Float[torch.Tensor, "n_nodes n_nodes"] | None = None,
+    ) -> Real[torch.Tensor, "n_nodes n_classes"] | Real[torch.Tensor, "n_nodes"]:
+        """Predict class probabilities (classification) or values (regression).
+
+        Args:
+            X: Feature matrix of points on the manifold, shape ``[n_nodes, dim]``.
+            A: Optional adjacency or distance matrix used as the attention mask.
+
+        Returns:
+            Predicted class probabilities / regression targets.
+        """
+        X = X.clone()
+        A = A.clone() if A is not None else None
+        A_hat = get_A_hat(A, make_symmetric=True, add_self_loops=True) if A is not None else None
+
+        self.eval()
+        with torch.no_grad():
+            return self(X, A_hat, softmax=self.task == "classification")
+
+    def __repr__(self) -> str:
+        """String representation of the `KappaTransformer`."""
+        return (
+            f"{self.__class__.__name__}(\n"
+            + f"  num_layers={self.num_layers},\n"
+            + f"  num_heads={self.num_heads},\n"
+            + f"  head_dim={self.head_dim},\n"
+            + f"  output_layer={repr(self.output_layer)},\n"
+            + f"  task='{self.task}',\n"
+            + f"  output_dim={self.output_dim}\n)"
+        )

--- a/manify/utils/benchmarks.py
+++ b/manify/utils/benchmarks.py
@@ -41,12 +41,7 @@ if TYPE_CHECKING:
     TASKTYPE: TypeAlias = Literal["classification", "regression", "link_prediction"]
 
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
-from sklearn.metrics import (
-    accuracy_score,
-    f1_score,
-    mean_squared_error,
-    root_mean_squared_error,
-)
+from sklearn.metrics import accuracy_score, f1_score, mean_squared_error, root_mean_squared_error
 from sklearn.model_selection import train_test_split
 from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 from sklearn.svm import SVC, SVR
@@ -259,18 +254,9 @@ def benchmark(
     X_test_tangent = pm.logmap(X_test).detach()
 
     # Get numpy versions
-    X_train_np, X_test_np = (
-        X_train.detach().cpu().numpy(),
-        X_test.detach().cpu().numpy(),
-    )
-    y_train_np, y_test_np = (
-        y_train.detach().cpu().numpy(),
-        y_test.detach().cpu().numpy(),
-    )
-    X_train_tangent_np, X_test_tangent_np = (
-        X_train_tangent.cpu().numpy(),
-        X_test_tangent.cpu().numpy(),
-    )
+    X_train_np, X_test_np = (X_train.detach().cpu().numpy(), X_test.detach().cpu().numpy())
+    y_train_np, y_test_np = (y_train.detach().cpu().numpy(), y_test.detach().cpu().numpy())
+    X_train_tangent_np, X_test_tangent_np = (X_train_tangent.cpu().numpy(), X_test_tangent.cpu().numpy())
 
     # Get stereographic version
     pm_stereo, X_train_stereo, X_test_stereo = pm.stereographic(X_train, X_test)
@@ -302,16 +288,8 @@ def benchmark(
         A_test = A_test.to(device).detach()
 
     # Aggregate arguments
-    tree_kwargs = {
-        "max_depth": max_depth,
-        "min_samples_leaf": min_samples_leaf,
-        "min_samples_split": min_samples_split,
-    }
-    prod_kwargs = {
-        "use_special_dims": use_special_dims,
-        "n_features": n_features,
-        "batch_size": batch_size,
-    }
+    tree_kwargs = {"max_depth": max_depth, "min_samples_leaf": min_samples_leaf, "min_samples_split": min_samples_split}
+    prod_kwargs = {"use_special_dims": use_special_dims, "n_features": n_features, "batch_size": batch_size}
     rf_kwargs = {"n_estimators": n_estimators, "n_jobs": -1, "random_state": seed}
     nn_outdim = 1 if task == "regression" else len(torch.unique(y))
     nn_kwargs = {"task": task, "output_dim": nn_outdim}
@@ -395,8 +373,7 @@ def benchmark(
         train_dists = torch.nan_to_num(train_dists, nan=train_dists[~train_dists.isnan()].max().item())
         train_test_dists = pm.dist(X_test, X_train)
         train_test_dists = torch.nan_to_num(
-            train_test_dists,
-            nan=train_test_dists[~train_test_dists.isnan()].max().item(),
+            train_test_dists, nan=train_test_dists[~train_test_dists.isnan()].max().item()
         )
 
         # Convert to numpy
@@ -435,10 +412,7 @@ def benchmark(
             accs["ps_perceptron"] = _score(X_test, y_test_np, ps_per, use_torch=True, score=score)
             accs["ps_perceptron"]["time"] = t2 - t1
         else:
-            warnings.warn(
-                "Product Space Perceptron is only implemented for classification tasks.",
-                stacklevel=2,
-            )
+            warnings.warn("Product Space Perceptron is only implemented for classification tasks.", stacklevel=2)
 
     if "svm" in models:
         # Get inner products for precomputed kernel matrix
@@ -477,31 +451,12 @@ def benchmark(
         ).to(device)
         t1 = time.time()
         if task == "link_prediction":
-            kappa_mlp.fit(
-                X_train_stereo,
-                y_train,
-                A=A_train,
-                tqdm_prefix="kappa_mlp",
-                **nn_train_kwargs,
-            )
+            kappa_mlp.fit(X_train_stereo, y_train, A=A_train, tqdm_prefix="kappa_mlp", **nn_train_kwargs)
         else:
-            kappa_mlp.fit(
-                X_train_stereo,
-                y_train,
-                A=None,
-                tqdm_prefix="kappa_mlp",
-                **nn_train_kwargs,
-            )
+            kappa_mlp.fit(X_train_stereo, y_train, A=None, tqdm_prefix="kappa_mlp", **nn_train_kwargs)
         t2 = time.time()
         y_pred = kappa_mlp.predict(X_test_stereo, A=None)
-        accs["kappa_mlp"] = _score(
-            None,
-            y_test_np,
-            kappa_mlp,
-            y_pred_override=y_pred,
-            use_torch=True,
-            score=score,
-        )
+        accs["kappa_mlp"] = _score(None, y_test_np, kappa_mlp, y_pred_override=y_pred, use_torch=True, score=score)
         accs["kappa_mlp"]["time"] = t2 - t1
 
     if "ambient_mlp" in models:
@@ -510,36 +465,16 @@ def benchmark(
         ambient_mlp.fit(X_train, y_train, A=None, tqdm_prefix="ambient_mlp", **nn_train_kwargs)
         t2 = time.time()
         y_pred = ambient_mlp.predict(X_test, A=None)
-        accs["ambient_mlp"] = _score(
-            None,
-            y_test_np,
-            ambient_mlp,
-            y_pred_override=y_pred,
-            use_torch=True,
-            score=score,
-        )
+        accs["ambient_mlp"] = _score(None, y_test_np, ambient_mlp, y_pred_override=y_pred, use_torch=True, score=score)
         accs["ambient_mlp"]["time"] = t2 - t1
 
     if "tangent_mlp" in models:
         tangent_mlp = KappaGCN(pm=pm_euc, num_hidden=kappa_gcn_layers, **nn_kwargs).to(device)  # type: ignore
         t1 = time.time()
-        tangent_mlp.fit(
-            X_train_tangent,
-            y_train,
-            A=None,
-            tqdm_prefix="tangent_mlp",
-            **nn_train_kwargs,
-        )
+        tangent_mlp.fit(X_train_tangent, y_train, A=None, tqdm_prefix="tangent_mlp", **nn_train_kwargs)
         t2 = time.time()
         y_pred = tangent_mlp.predict(X_test_tangent, A=None)
-        accs["tangent_mlp"] = _score(
-            None,
-            y_test_np,
-            tangent_mlp,
-            y_pred_override=y_pred,
-            use_torch=True,
-            score=score,
-        )
+        accs["tangent_mlp"] = _score(None, y_test_np, tangent_mlp, y_pred_override=y_pred, use_torch=True, score=score)
         accs["tangent_mlp"]["time"] = t2 - t1
 
     if "ambient_gcn" in models:
@@ -554,13 +489,7 @@ def benchmark(
     if "tangent_gcn" in models:
         tangent_gcn = KappaGCN(pm=pm_euc, num_hidden=kappa_gcn_layers, **nn_kwargs).to(device)  # type: ignore
         t1 = time.time()
-        tangent_gcn.fit(
-            X_train_tangent,
-            y_train,
-            A=A_train,
-            tqdm_prefix="tangent_gcn",
-            **nn_train_kwargs,
-        )
+        tangent_gcn.fit(X_train_tangent, y_train, A=A_train, tqdm_prefix="tangent_gcn", **nn_train_kwargs)
         t2 = time.time()
         y_pred = tangent_gcn.predict(X_test_tangent, A=A_test)
         accs["tangent_gcn"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
@@ -570,13 +499,7 @@ def benchmark(
         assert isinstance(X_test_stereo, torch.Tensor)
         kappa_gcn = KappaGCN(pm=pm_stereo, num_hidden=kappa_gcn_layers, task=task, output_dim=nn_outdim).to(device)  # type: ignore
         t1 = time.time()
-        kappa_gcn.fit(
-            X_train_stereo,
-            y_train,
-            A=A_train,
-            tqdm_prefix="kappa_gcn",
-            **nn_train_kwargs,
-        )
+        kappa_gcn.fit(X_train_stereo, y_train, A=A_train, tqdm_prefix="kappa_gcn", **nn_train_kwargs)
         t2 = time.time()
         y_pred = kappa_gcn.predict(X_test_stereo, A=A_test)
         accs["kappa_gcn"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
@@ -584,10 +507,7 @@ def benchmark(
 
     if "kappa_transformer" in models:
         if task == "link_prediction":
-            warnings.warn(
-                "kappa_transformer only supports classification/regression; skipping.",
-                stacklevel=2,
-            )
+            warnings.warn("kappa_transformer only supports classification/regression; skipping.", stacklevel=2)
         else:
             assert isinstance(X_test_stereo, torch.Tensor)
             # head_dim must divide pm.dim across heads; fall back to 1 head for tiny manifolds.
@@ -601,21 +521,12 @@ def benchmark(
             ).to(device)
             t1 = time.time()
             kappa_transformer.fit(
-                X_train_stereo,
-                y_train,
-                A=A_train,
-                tqdm_prefix="kappa_transformer",
-                **nn_train_kwargs,
+                X_train_stereo, y_train, A=A_train, tqdm_prefix="kappa_transformer", **nn_train_kwargs
             )
             t2 = time.time()
             y_pred = kappa_transformer.predict(X_test_stereo, A=A_test)
             accs["kappa_transformer"] = _score(
-                None,
-                y_test_np,
-                None,
-                y_pred_override=y_pred,
-                use_torch=True,
-                score=score,
+                None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score
             )
             accs["kappa_transformer"]["time"] = t2 - t1
 
@@ -631,13 +542,7 @@ def benchmark(
     if "tangent_mlr" in models:
         tangent_mlr = KappaGCN(pm=pm_euc, num_hidden=0, task=task, output_dim=nn_outdim).to(device)  # type: ignore
         t1 = time.time()
-        tangent_mlr.fit(
-            X_train_tangent,
-            y_train,
-            A=None,
-            tqdm_prefix="tangent_mlr",
-            **nn_train_kwargs,
-        )
+        tangent_mlr.fit(X_train_tangent, y_train, A=None, tqdm_prefix="tangent_mlr", **nn_train_kwargs)
         t2 = time.time()
         y_pred = tangent_mlr.predict(X_test_tangent, A=None)
         accs["tangent_mlr"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)

--- a/manify/utils/benchmarks.py
+++ b/manify/utils/benchmarks.py
@@ -512,9 +512,12 @@ def benchmark(
             assert isinstance(X_test_stereo, torch.Tensor)
             # head_dim must divide pm.dim across heads; fall back to 1 head for tiny manifolds.
             n_heads = 2 if pm_stereo.dim >= 2 else 1
+            # The transformer block is attention + residual; it needs at least a couple of blocks to
+            # be competitive (a single block barely moves signal past the residual), unlike a GCN conv.
+            n_layers = max(2, kappa_gcn_layers)
             kappa_transformer = KappaTransformer(
                 pm=pm_stereo,
-                num_layers=kappa_gcn_layers,
+                num_layers=n_layers,
                 num_heads=n_heads,
                 task=task,
                 output_dim=nn_outdim,  # type: ignore

--- a/manify/utils/benchmarks.py
+++ b/manify/utils/benchmarks.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
         "tangent_gcn",
         "ambient_gcn",
         "kappa_gcn",
+        "kappa_transformer",
         "ambient_mlr",
         "tangent_mlr",
         "kappa_mlr",
@@ -40,7 +41,12 @@ if TYPE_CHECKING:
     TASKTYPE: TypeAlias = Literal["classification", "regression", "link_prediction"]
 
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
-from sklearn.metrics import accuracy_score, f1_score, mean_squared_error, root_mean_squared_error
+from sklearn.metrics import (
+    accuracy_score,
+    f1_score,
+    mean_squared_error,
+    root_mean_squared_error,
+)
 from sklearn.model_selection import train_test_split
 from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 from sklearn.svm import SVC, SVR
@@ -51,6 +57,7 @@ from ..predictors.decision_tree import ProductSpaceDT, ProductSpaceRF
 from ..predictors.kappa_gcn import KappaGCN, get_A_hat
 from ..predictors.perceptron import ProductSpacePerceptron
 from ..predictors.svm import ProductSpaceSVM
+from ..predictors.transformer import KappaTransformer
 
 
 def _score(
@@ -180,6 +187,7 @@ def benchmark(
         "tangent_gcn",
         "ambient_gcn",
         "kappa_gcn",
+        "kappa_transformer",
         "ambient_mlr",
         "tangent_mlr",
         "kappa_mlr",
@@ -251,9 +259,18 @@ def benchmark(
     X_test_tangent = pm.logmap(X_test).detach()
 
     # Get numpy versions
-    X_train_np, X_test_np = X_train.detach().cpu().numpy(), X_test.detach().cpu().numpy()
-    y_train_np, y_test_np = y_train.detach().cpu().numpy(), y_test.detach().cpu().numpy()
-    X_train_tangent_np, X_test_tangent_np = X_train_tangent.cpu().numpy(), X_test_tangent.cpu().numpy()
+    X_train_np, X_test_np = (
+        X_train.detach().cpu().numpy(),
+        X_test.detach().cpu().numpy(),
+    )
+    y_train_np, y_test_np = (
+        y_train.detach().cpu().numpy(),
+        y_test.detach().cpu().numpy(),
+    )
+    X_train_tangent_np, X_test_tangent_np = (
+        X_train_tangent.cpu().numpy(),
+        X_test_tangent.cpu().numpy(),
+    )
 
     # Get stereographic version
     pm_stereo, X_train_stereo, X_test_stereo = pm.stereographic(X_train, X_test)
@@ -285,8 +302,16 @@ def benchmark(
         A_test = A_test.to(device).detach()
 
     # Aggregate arguments
-    tree_kwargs = {"max_depth": max_depth, "min_samples_leaf": min_samples_leaf, "min_samples_split": min_samples_split}
-    prod_kwargs = {"use_special_dims": use_special_dims, "n_features": n_features, "batch_size": batch_size}
+    tree_kwargs = {
+        "max_depth": max_depth,
+        "min_samples_leaf": min_samples_leaf,
+        "min_samples_split": min_samples_split,
+    }
+    prod_kwargs = {
+        "use_special_dims": use_special_dims,
+        "n_features": n_features,
+        "batch_size": batch_size,
+    }
     rf_kwargs = {"n_estimators": n_estimators, "n_jobs": -1, "random_state": seed}
     nn_outdim = 1 if task == "regression" else len(torch.unique(y))
     nn_kwargs = {"task": task, "output_dim": nn_outdim}
@@ -410,7 +435,10 @@ def benchmark(
             accs["ps_perceptron"] = _score(X_test, y_test_np, ps_per, use_torch=True, score=score)
             accs["ps_perceptron"]["time"] = t2 - t1
         else:
-            warnings.warn("Product Space Perceptron is only implemented for classification tasks.", stacklevel=2)
+            warnings.warn(
+                "Product Space Perceptron is only implemented for classification tasks.",
+                stacklevel=2,
+            )
 
     if "svm" in models:
         # Get inner products for precomputed kernel matrix
@@ -449,12 +477,31 @@ def benchmark(
         ).to(device)
         t1 = time.time()
         if task == "link_prediction":
-            kappa_mlp.fit(X_train_stereo, y_train, A=A_train, tqdm_prefix="kappa_mlp", **nn_train_kwargs)
+            kappa_mlp.fit(
+                X_train_stereo,
+                y_train,
+                A=A_train,
+                tqdm_prefix="kappa_mlp",
+                **nn_train_kwargs,
+            )
         else:
-            kappa_mlp.fit(X_train_stereo, y_train, A=None, tqdm_prefix="kappa_mlp", **nn_train_kwargs)
+            kappa_mlp.fit(
+                X_train_stereo,
+                y_train,
+                A=None,
+                tqdm_prefix="kappa_mlp",
+                **nn_train_kwargs,
+            )
         t2 = time.time()
         y_pred = kappa_mlp.predict(X_test_stereo, A=None)
-        accs["kappa_mlp"] = _score(None, y_test_np, kappa_mlp, y_pred_override=y_pred, use_torch=True, score=score)
+        accs["kappa_mlp"] = _score(
+            None,
+            y_test_np,
+            kappa_mlp,
+            y_pred_override=y_pred,
+            use_torch=True,
+            score=score,
+        )
         accs["kappa_mlp"]["time"] = t2 - t1
 
     if "ambient_mlp" in models:
@@ -463,16 +510,36 @@ def benchmark(
         ambient_mlp.fit(X_train, y_train, A=None, tqdm_prefix="ambient_mlp", **nn_train_kwargs)
         t2 = time.time()
         y_pred = ambient_mlp.predict(X_test, A=None)
-        accs["ambient_mlp"] = _score(None, y_test_np, ambient_mlp, y_pred_override=y_pred, use_torch=True, score=score)
+        accs["ambient_mlp"] = _score(
+            None,
+            y_test_np,
+            ambient_mlp,
+            y_pred_override=y_pred,
+            use_torch=True,
+            score=score,
+        )
         accs["ambient_mlp"]["time"] = t2 - t1
 
     if "tangent_mlp" in models:
         tangent_mlp = KappaGCN(pm=pm_euc, num_hidden=kappa_gcn_layers, **nn_kwargs).to(device)  # type: ignore
         t1 = time.time()
-        tangent_mlp.fit(X_train_tangent, y_train, A=None, tqdm_prefix="tangent_mlp", **nn_train_kwargs)
+        tangent_mlp.fit(
+            X_train_tangent,
+            y_train,
+            A=None,
+            tqdm_prefix="tangent_mlp",
+            **nn_train_kwargs,
+        )
         t2 = time.time()
         y_pred = tangent_mlp.predict(X_test_tangent, A=None)
-        accs["tangent_mlp"] = _score(None, y_test_np, tangent_mlp, y_pred_override=y_pred, use_torch=True, score=score)
+        accs["tangent_mlp"] = _score(
+            None,
+            y_test_np,
+            tangent_mlp,
+            y_pred_override=y_pred,
+            use_torch=True,
+            score=score,
+        )
         accs["tangent_mlp"]["time"] = t2 - t1
 
     if "ambient_gcn" in models:
@@ -487,7 +554,13 @@ def benchmark(
     if "tangent_gcn" in models:
         tangent_gcn = KappaGCN(pm=pm_euc, num_hidden=kappa_gcn_layers, **nn_kwargs).to(device)  # type: ignore
         t1 = time.time()
-        tangent_gcn.fit(X_train_tangent, y_train, A=A_train, tqdm_prefix="tangent_gcn", **nn_train_kwargs)
+        tangent_gcn.fit(
+            X_train_tangent,
+            y_train,
+            A=A_train,
+            tqdm_prefix="tangent_gcn",
+            **nn_train_kwargs,
+        )
         t2 = time.time()
         y_pred = tangent_gcn.predict(X_test_tangent, A=A_test)
         accs["tangent_gcn"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
@@ -497,11 +570,54 @@ def benchmark(
         assert isinstance(X_test_stereo, torch.Tensor)
         kappa_gcn = KappaGCN(pm=pm_stereo, num_hidden=kappa_gcn_layers, task=task, output_dim=nn_outdim).to(device)  # type: ignore
         t1 = time.time()
-        kappa_gcn.fit(X_train_stereo, y_train, A=A_train, tqdm_prefix="kappa_gcn", **nn_train_kwargs)
+        kappa_gcn.fit(
+            X_train_stereo,
+            y_train,
+            A=A_train,
+            tqdm_prefix="kappa_gcn",
+            **nn_train_kwargs,
+        )
         t2 = time.time()
         y_pred = kappa_gcn.predict(X_test_stereo, A=A_test)
         accs["kappa_gcn"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)
         accs["kappa_gcn"]["time"] = t2 - t1
+
+    if "kappa_transformer" in models:
+        if task == "link_prediction":
+            warnings.warn(
+                "kappa_transformer only supports classification/regression; skipping.",
+                stacklevel=2,
+            )
+        else:
+            assert isinstance(X_test_stereo, torch.Tensor)
+            # head_dim must divide pm.dim across heads; fall back to 1 head for tiny manifolds.
+            n_heads = 2 if pm_stereo.dim >= 2 else 1
+            kappa_transformer = KappaTransformer(
+                pm=pm_stereo,
+                num_layers=kappa_gcn_layers,
+                num_heads=n_heads,
+                task=task,
+                output_dim=nn_outdim,  # type: ignore
+            ).to(device)
+            t1 = time.time()
+            kappa_transformer.fit(
+                X_train_stereo,
+                y_train,
+                A=A_train,
+                tqdm_prefix="kappa_transformer",
+                **nn_train_kwargs,
+            )
+            t2 = time.time()
+            y_pred = kappa_transformer.predict(X_test_stereo, A=A_test)
+            accs["kappa_transformer"] = _score(
+                None,
+                y_test_np,
+                None,
+                y_pred_override=y_pred,
+                use_torch=True,
+                score=score,
+            )
+            accs["kappa_transformer"]["time"] = t2 - t1
 
     if "kappa_mlr" in models:
         kappa_mlr = KappaGCN(pm=pm_stereo, num_hidden=0, task=task, output_dim=nn_outdim).to(device)  # type: ignore
@@ -515,7 +631,13 @@ def benchmark(
     if "tangent_mlr" in models:
         tangent_mlr = KappaGCN(pm=pm_euc, num_hidden=0, task=task, output_dim=nn_outdim).to(device)  # type: ignore
         t1 = time.time()
-        tangent_mlr.fit(X_train_tangent, y_train, A=None, tqdm_prefix="tangent_mlr", **nn_train_kwargs)
+        tangent_mlr.fit(
+            X_train_tangent,
+            y_train,
+            A=None,
+            tqdm_prefix="tangent_mlr",
+            **nn_train_kwargs,
+        )
         t2 = time.time()
         y_pred = tangent_mlr.predict(X_test_tangent, A=None)
         accs["tangent_mlr"] = _score(None, y_test_np, None, y_pred_override=y_pred, use_torch=True, score=score)

--- a/tests/test_nn_layers.py
+++ b/tests/test_nn_layers.py
@@ -3,7 +3,10 @@
 Points are always built via ``pm.stereographic(X)`` (never ``pm.sample`` on a stereographic
 manifold, which crashes). Tests cover: smoke/shape, on-manifold validity, permutation equivariance,
 masking (an edge that is masked out cannot let one node influence another), gradient finiteness, the
-curvature -> 0 Euclidean limit, and determinism under a fixed seed.
+curvature -> 0 Euclidean limit, determinism under a fixed seed, and -- crucially -- that the
+aggregation is the gyrovector Einstein midpoint (it differs from the Euclidean mean of the value
+points at finite curvature and converges to it as curvature -> 0), guarding against a tangent-space
+/ Euclidean-mean shortcut.
 """
 
 import torch
@@ -123,24 +126,34 @@ def test_gradient_finiteness():
 
 
 def test_kappa_to_zero_euclidean_limit():
-    """As curvature -> 0 the block approaches a plain Euclidean linear-attention block."""
+    """As curvature -> 0 (input pm AND per-head curvatures) the block approaches Euclidean.
+
+    The faithful block reduces to a Euclidean linear-attention transformer only when BOTH the input
+    manifold and the learnable per-head curvatures vanish; we drive both to zero together.
+    """
     torch.manual_seed(6)
     X = torch.randn(6, 4) * 0.1
 
-    # Euclidean reference (curvature 0): logmap0/expmap0 are identities.
+    # Euclidean reference: input curvature 0 and per-head curvatures 0.
     pm0 = ProductManifold(signature=[(0.0, 4)], stereographic=True)
-    block0 = StereographicTransformer(pm0, num_heads=2, dim=4, head_dim=3, use_layer_norm=False).eval()
+    block0 = StereographicTransformer(
+        pm0, num_heads=2, dim=4, head_dim=3, use_layer_norm=False, init_curvatures=[0.0, 0.0]
+    ).eval()
     with torch.no_grad():
         out0 = block0(X)
     assert pm0.manifold.check_point(out0)
 
-    # Small-curvature manifolds with identical weights should approach the Euclidean output.
+    # Small-curvature manifolds (and per-head curvatures) with identical weights should converge.
     prev = None
     for eps in (1e-1, 1e-2, 1e-3):
         pm_eps = ProductManifold(signature=[(-eps, 2), (eps, 2)], stereographic=True)
-        block_eps = StereographicTransformer(pm_eps, num_heads=2, dim=4, head_dim=3, use_layer_norm=False).eval()
-        block_eps.load_state_dict(block0.state_dict())
+        block_eps = StereographicTransformer(
+            pm_eps, num_heads=2, dim=4, head_dim=3, use_layer_norm=False, init_curvatures=[-eps, eps]
+        ).eval()
+        # Copy Euclidean weights, then set the per-head curvatures to +/- eps.
+        block_eps.load_state_dict(block0.state_dict(), strict=False)
         with torch.no_grad():
+            block_eps.mha.curvatures.copy_(torch.tensor([-eps, eps]))
             out_eps = block_eps(X)
         err = (out_eps - out0).abs().max().item()
         assert torch.isfinite(out_eps).all() and out_eps.shape == out0.shape
@@ -149,6 +162,47 @@ def test_kappa_to_zero_euclidean_limit():
         prev = err
     # At the smallest curvature the block is close to Euclidean (loose tolerance).
     assert prev < 1e-2, f"kappa->0 limit too far from Euclidean reference: {prev}"
+
+
+def test_aggregation_is_einstein_midpoint_not_euclidean_mean():
+    """The aggregation is the gyrovector Einstein midpoint, NOT the Euclidean mean of values.
+
+    With zero queries/keys (uniform attention weights) the attention output is the Einstein midpoint
+    of the value points. At finite curvature this must DIFFER from the arithmetic mean of the value
+    points, and it must converge to that mean as curvature -> 0. This is the test that catches a
+    tangent-space / Euclidean-mean shortcut.
+    """
+    from geoopt.manifolds.stereographic import math as smath
+
+    torch.manual_seed(11)
+    n_heads, n, head_dim = 1, 6, 3
+    attn = GeometricLinearizedAttention(num_heads=n_heads, head_dim=head_dim)
+    # Uniform weights: phi(elu(0)+1)=1 everywhere -> equal attention over all values.
+    Q = torch.zeros(n_heads, n, head_dim)
+    K = torch.zeros(n_heads, n, head_dim)
+
+    prev_gap = None
+    finite_curvature_gap = None
+    for kv in (1.0, 1e-1, 1e-2, 1e-3, 1e-4):
+        k = torch.full((n_heads, 1, 1), float(kv))
+        V = smath.project(torch.randn(n_heads, n, head_dim) * 0.3, k=k)
+        with torch.no_grad():
+            out = attn(Q, K, V, curvatures=k, mask=torch.ones(n, n))
+        # Every query gets the same (uniform) midpoint; compare against the Euclidean mean.
+        midpoint = out[0, 0]
+        euclidean_mean = V[0].mean(dim=0)
+        gap = (midpoint - euclidean_mean).norm().item()
+        if kv == 1.0:
+            finite_curvature_gap = gap
+        if prev_gap is not None:
+            assert gap < prev_gap, "Einstein midpoint should approach the Euclidean mean as kappa -> 0"
+        prev_gap = gap
+
+    assert finite_curvature_gap is not None and finite_curvature_gap > 1e-3, (
+        "At finite curvature the Einstein midpoint must differ from the Euclidean mean "
+        f"(got gap={finite_curvature_gap})"
+    )
+    assert prev_gap < 1e-3, f"Einstein midpoint should converge to the Euclidean mean as kappa->0 (got {prev_gap})"
 
 
 def test_determinism_fixed_seed():
@@ -168,14 +222,51 @@ def test_determinism_fixed_seed():
 
 
 def test_geometric_linearized_attention_full_matches_masked():
-    """Full-attention fast path equals the all-ones masked path (same kernel attention)."""
+    """The kernelized full-attention path equals the all-ones masked path exactly."""
+    from geoopt.manifolds.stereographic import math as smath
+
     torch.manual_seed(8)
     n_heads, n, head_dim = 2, 5, 3
-    Q = torch.randn(n_heads, n, head_dim)
-    K = torch.randn(n_heads, n, head_dim)
-    V = torch.randn(n_heads, n, head_dim)
+    k = torch.tensor([-1.0, 1.0]).view(n_heads, 1, 1)
+    V = smath.project(torch.randn(n_heads, n, head_dim) * 0.2, k=k)
+    Q = torch.randn(n_heads, n, head_dim) * 0.2
+    K = torch.randn(n_heads, n, head_dim) * 0.2
 
     attn = GeometricLinearizedAttention(num_heads=n_heads, head_dim=head_dim)
-    out_full = attn(Q, K, V, None)
-    out_ones = attn(Q, K, V, torch.ones(n, n))
+    out_full = attn(Q, K, V, curvatures=k, mask=None)
+    out_ones = attn(Q, K, V, curvatures=k, mask=torch.ones(n, n))
     assert torch.allclose(out_full, out_ones, atol=1e-5), "None mask should equal an all-ones mask"
+
+
+def test_geometric_linearized_attention_matches_brute_force_midpoint():
+    """The kernelized aggregation equals a brute-force Einstein-midpoint computation."""
+    from geoopt.manifolds.stereographic import math as smath
+
+    torch.manual_seed(9)
+    n_heads, n, head_dim = 1, 4, 3
+    k = torch.tensor([1.0]).view(n_heads, 1, 1)
+    V = smath.project(torch.randn(n_heads, n, head_dim) * 0.2, k=k)
+    Q = torch.randn(n_heads, n, head_dim) * 0.2
+    K = torch.randn(n_heads, n, head_dim) * 0.2
+
+    attn = GeometricLinearizedAttention(num_heads=n_heads, head_dim=head_dim)
+    with torch.no_grad():
+        out = attn(Q, K, V, curvatures=k, mask=torch.ones(n, n))
+
+    # Brute-force Einstein midpoint (Eq 7).
+    q_tilde = smath.parallel_transport0back(V, Q, k=k)
+    k_tilde = smath.parallel_transport0back(V, K, k=k)
+    phi_q = torch.nn.functional.elu(q_tilde) + 1
+    phi_k = torch.nn.functional.elu(k_tilde) + 1
+    alpha = torch.einsum("hnd,hmd->hnm", phi_q, phi_k)  # [H, N, N]
+    lam = smath.lambda_x(x=V, k=k, keepdim=True, dim=-1)  # [H, N, 1]
+    out_bf = torch.zeros(n_heads, n, head_dim)
+    for i in range(n):
+        denom = (alpha[0, i] * (lam[0, :, 0] - 1)).sum()
+        coef = alpha[0, i] * lam[0, :, 0] / denom
+        out_bf[0, i] = (coef[:, None] * V[0]).sum(0)
+    out_bf = smath.project(out_bf, k=k)
+    out_bf = smath.mobius_scalar_mul(torch.tensor(0.5), out_bf, k=k, dim=-1)
+    out_bf = smath.project(out_bf, k=k)
+
+    assert torch.allclose(out, out_bf, atol=1e-5), "Kernelized aggregation must match brute-force Einstein midpoint"

--- a/tests/test_nn_layers.py
+++ b/tests/test_nn_layers.py
@@ -59,9 +59,7 @@ def test_outputs_on_manifold():
         out_masked = block(X, torch.ones(X.shape[0], X.shape[0]))
 
     for o in (out, out_masked):
-        assert pm.manifold.check_point(
-            o
-        ), "Output must lie on the stereographic manifold"
+        assert pm.manifold.check_point(o), "Output must lie on the stereographic manifold"
         # Projection idempotence within tolerance.
         assert torch.allclose(pm.manifold.projx(o), o, atol=1e-4)
 
@@ -76,27 +74,21 @@ def test_permutation_equivariance_full_mask():
     with torch.no_grad():
         out = block(X)
         out_perm = block(X[perm])
-    assert torch.allclose(
-        out[perm], out_perm, atol=ATOL
-    ), "Block must be permutation equivariant (None mask)"
+    assert torch.allclose(out[perm], out_perm, atol=ATOL), "Block must be permutation equivariant (None mask)"
 
     # Same with an explicit all-ones mask (also permuted along both axes).
     mask = torch.ones(n, n)
     with torch.no_grad():
         out2 = block(X, mask)
         out2_perm = block(X[perm], mask[perm][:, perm])
-    assert torch.allclose(
-        out2[perm], out2_perm, atol=ATOL
-    ), "Block must be permutation equivariant (ones mask)"
+    assert torch.allclose(out2[perm], out2_perm, atol=ATOL), "Block must be permutation equivariant (ones mask)"
 
 
 def test_masking_blocks_influence():
     """A masked-out edge cannot let one node influence another's output."""
     pm, X = _make_points(SIGNATURE, n_nodes=6, seed=4)
     n, d = X.shape
-    block = StereographicTransformer(
-        pm, num_heads=2, dim=d, head_dim=3, use_layer_norm=False
-    ).eval()
+    block = StereographicTransformer(pm, num_heads=2, dim=d, head_dim=3, use_layer_norm=False).eval()
 
     # Diagonal mask: each node attends only to itself, so node 0 cannot see node 1.
     mask = torch.eye(n)
@@ -107,12 +99,8 @@ def test_masking_blocks_influence():
         out = block(X, mask)
         out_perturbed = block(X_perturbed, mask)
 
-    assert torch.allclose(
-        out[0], out_perturbed[0], atol=1e-6
-    ), "Masked-out node 1 must not affect node 0"
-    assert not torch.allclose(
-        out[1], out_perturbed[1], atol=1e-6
-    ), "Node 1's own perturbation should change its output"
+    assert torch.allclose(out[0], out_perturbed[0], atol=1e-6), "Masked-out node 1 must not affect node 0"
+    assert not torch.allclose(out[1], out_perturbed[1], atol=1e-6), "Node 1's own perturbation should change its output"
 
 
 def test_gradient_finiteness():
@@ -129,9 +117,7 @@ def test_gradient_finiteness():
     for name, p in block.named_parameters():
         if p.requires_grad:
             assert p.grad is not None, f"Parameter {name} received no gradient"
-            assert torch.isfinite(
-                p.grad
-            ).all(), f"Parameter {name} has non-finite gradient"
+            assert torch.isfinite(p.grad).all(), f"Parameter {name} has non-finite gradient"
             n_grad += 1
     assert n_grad > 0, "Block should have trainable parameters"
 
@@ -143,9 +129,7 @@ def test_kappa_to_zero_euclidean_limit():
 
     # Euclidean reference (curvature 0): logmap0/expmap0 are identities.
     pm0 = ProductManifold(signature=[(0.0, 4)], stereographic=True)
-    block0 = StereographicTransformer(
-        pm0, num_heads=2, dim=4, head_dim=3, use_layer_norm=False
-    ).eval()
+    block0 = StereographicTransformer(pm0, num_heads=2, dim=4, head_dim=3, use_layer_norm=False).eval()
     with torch.no_grad():
         out0 = block0(X)
     assert pm0.manifold.check_point(out0)
@@ -154,18 +138,14 @@ def test_kappa_to_zero_euclidean_limit():
     prev = None
     for eps in (1e-1, 1e-2, 1e-3):
         pm_eps = ProductManifold(signature=[(-eps, 2), (eps, 2)], stereographic=True)
-        block_eps = StereographicTransformer(
-            pm_eps, num_heads=2, dim=4, head_dim=3, use_layer_norm=False
-        ).eval()
+        block_eps = StereographicTransformer(pm_eps, num_heads=2, dim=4, head_dim=3, use_layer_norm=False).eval()
         block_eps.load_state_dict(block0.state_dict())
         with torch.no_grad():
             out_eps = block_eps(X)
         err = (out_eps - out0).abs().max().item()
         assert torch.isfinite(out_eps).all() and out_eps.shape == out0.shape
         if prev is not None:
-            assert (
-                err < prev
-            ), "Output should approach the Euclidean limit as curvature shrinks"
+            assert err < prev, "Output should approach the Euclidean limit as curvature shrinks"
         prev = err
     # At the smallest curvature the block is close to Euclidean (loose tolerance).
     assert prev < 1e-2, f"kappa->0 limit too far from Euclidean reference: {prev}"
@@ -184,9 +164,7 @@ def test_determinism_fixed_seed():
     with torch.no_grad():
         out_a = block_a(X)
         out_b = block_b(X)
-    assert torch.allclose(
-        out_a, out_b, atol=0.0
-    ), "Same seed must give identical outputs"
+    assert torch.allclose(out_a, out_b, atol=0.0), "Same seed must give identical outputs"
 
 
 def test_geometric_linearized_attention_full_matches_masked():
@@ -200,6 +178,4 @@ def test_geometric_linearized_attention_full_matches_masked():
     attn = GeometricLinearizedAttention(num_heads=n_heads, head_dim=head_dim)
     out_full = attn(Q, K, V, None)
     out_ones = attn(Q, K, V, torch.ones(n, n))
-    assert torch.allclose(
-        out_full, out_ones, atol=1e-5
-    ), "None mask should equal an all-ones mask"
+    assert torch.allclose(out_full, out_ones, atol=1e-5), "None mask should equal an all-ones mask"

--- a/tests/test_nn_layers.py
+++ b/tests/test_nn_layers.py
@@ -1,0 +1,205 @@
+"""Oracle-free semantic tests for the stereographic transformer layers.
+
+Points are always built via ``pm.stereographic(X)`` (never ``pm.sample`` on a stereographic
+manifold, which crashes). Tests cover: smoke/shape, on-manifold validity, permutation equivariance,
+masking (an edge that is masked out cannot let one node influence another), gradient finiteness, the
+curvature -> 0 Euclidean limit, and determinism under a fixed seed.
+"""
+
+import torch
+
+from manify.manifolds import ProductManifold
+from manify.predictors.nn.layers import (
+    GeometricLinearizedAttention,
+    StereographicAttention,
+    StereographicLayerNorm,
+    StereographicTransformer,
+)
+
+ATOL = 1e-5
+
+
+def _make_points(signature, n_nodes=8, seed=0):
+    """Build on-manifold stereographic points via the sample -> stereographic path."""
+    torch.manual_seed(seed)
+    pm = ProductManifold(signature=signature)
+    X = pm.sample(n_nodes)
+    pm_stereo, X_stereo = pm.stereographic(X)
+    return pm_stereo, X_stereo
+
+
+SIGNATURE = [(-1.0, 2), (0.0, 2), (1.0, 2)]
+
+
+def test_layers_smoke_and_shape():
+    """Each layer and the full block run and return [n_nodes, dim]."""
+    pm, X = _make_points(SIGNATURE, n_nodes=7, seed=1)
+    n, d = X.shape
+
+    ln = StereographicLayerNorm(pm, d)
+    assert ln(X).shape == (n, d)
+
+    attn = StereographicAttention(pm, num_heads=2, dim=d, head_dim=3)
+    assert attn(X).shape == (n, d)
+    assert attn(X, torch.ones(n, n)).shape == (n, d)
+
+    block = StereographicTransformer(pm, num_heads=2, dim=d, head_dim=3)
+    assert block(X).shape == (n, d)
+    assert block(X, torch.ones(n, n)).shape == (n, d)
+
+
+def test_outputs_on_manifold():
+    """Outputs are valid stereographic points (check_point + projection idempotence)."""
+    pm, X = _make_points(SIGNATURE, n_nodes=9, seed=2)
+    d = X.shape[1]
+
+    block = StereographicTransformer(pm, num_heads=3, dim=d, head_dim=2).eval()
+    with torch.no_grad():
+        out = block(X)
+        out_masked = block(X, torch.ones(X.shape[0], X.shape[0]))
+
+    for o in (out, out_masked):
+        assert pm.manifold.check_point(
+            o
+        ), "Output must lie on the stereographic manifold"
+        # Projection idempotence within tolerance.
+        assert torch.allclose(pm.manifold.projx(o), o, atol=1e-4)
+
+
+def test_permutation_equivariance_full_mask():
+    """Permuting input nodes permutes outputs identically under full attention."""
+    pm, X = _make_points(SIGNATURE, n_nodes=8, seed=3)
+    n, d = X.shape
+    block = StereographicTransformer(pm, num_heads=2, dim=d, head_dim=3).eval()
+
+    perm = torch.randperm(n)
+    with torch.no_grad():
+        out = block(X)
+        out_perm = block(X[perm])
+    assert torch.allclose(
+        out[perm], out_perm, atol=ATOL
+    ), "Block must be permutation equivariant (None mask)"
+
+    # Same with an explicit all-ones mask (also permuted along both axes).
+    mask = torch.ones(n, n)
+    with torch.no_grad():
+        out2 = block(X, mask)
+        out2_perm = block(X[perm], mask[perm][:, perm])
+    assert torch.allclose(
+        out2[perm], out2_perm, atol=ATOL
+    ), "Block must be permutation equivariant (ones mask)"
+
+
+def test_masking_blocks_influence():
+    """A masked-out edge cannot let one node influence another's output."""
+    pm, X = _make_points(SIGNATURE, n_nodes=6, seed=4)
+    n, d = X.shape
+    block = StereographicTransformer(
+        pm, num_heads=2, dim=d, head_dim=3, use_layer_norm=False
+    ).eval()
+
+    # Diagonal mask: each node attends only to itself, so node 0 cannot see node 1.
+    mask = torch.eye(n)
+    X_perturbed = X.clone()
+    X_perturbed[1] = pm.manifold.projx(X[1] + 0.5 * torch.randn(d))
+
+    with torch.no_grad():
+        out = block(X, mask)
+        out_perturbed = block(X_perturbed, mask)
+
+    assert torch.allclose(
+        out[0], out_perturbed[0], atol=1e-6
+    ), "Masked-out node 1 must not affect node 0"
+    assert not torch.allclose(
+        out[1], out_perturbed[1], atol=1e-6
+    ), "Node 1's own perturbation should change its output"
+
+
+def test_gradient_finiteness():
+    """Backward from a scalar loss yields finite grads for every parameter."""
+    pm, X = _make_points(SIGNATURE, n_nodes=7, seed=5)
+    d = X.shape[1]
+    block = StereographicTransformer(pm, num_heads=2, dim=d, head_dim=3)
+
+    out = block(X, torch.ones(X.shape[0], X.shape[0]))
+    loss = out.pow(2).sum()
+    loss.backward()
+
+    n_grad = 0
+    for name, p in block.named_parameters():
+        if p.requires_grad:
+            assert p.grad is not None, f"Parameter {name} received no gradient"
+            assert torch.isfinite(
+                p.grad
+            ).all(), f"Parameter {name} has non-finite gradient"
+            n_grad += 1
+    assert n_grad > 0, "Block should have trainable parameters"
+
+
+def test_kappa_to_zero_euclidean_limit():
+    """As curvature -> 0 the block approaches a plain Euclidean linear-attention block."""
+    torch.manual_seed(6)
+    X = torch.randn(6, 4) * 0.1
+
+    # Euclidean reference (curvature 0): logmap0/expmap0 are identities.
+    pm0 = ProductManifold(signature=[(0.0, 4)], stereographic=True)
+    block0 = StereographicTransformer(
+        pm0, num_heads=2, dim=4, head_dim=3, use_layer_norm=False
+    ).eval()
+    with torch.no_grad():
+        out0 = block0(X)
+    assert pm0.manifold.check_point(out0)
+
+    # Small-curvature manifolds with identical weights should approach the Euclidean output.
+    prev = None
+    for eps in (1e-1, 1e-2, 1e-3):
+        pm_eps = ProductManifold(signature=[(-eps, 2), (eps, 2)], stereographic=True)
+        block_eps = StereographicTransformer(
+            pm_eps, num_heads=2, dim=4, head_dim=3, use_layer_norm=False
+        ).eval()
+        block_eps.load_state_dict(block0.state_dict())
+        with torch.no_grad():
+            out_eps = block_eps(X)
+        err = (out_eps - out0).abs().max().item()
+        assert torch.isfinite(out_eps).all() and out_eps.shape == out0.shape
+        if prev is not None:
+            assert (
+                err < prev
+            ), "Output should approach the Euclidean limit as curvature shrinks"
+        prev = err
+    # At the smallest curvature the block is close to Euclidean (loose tolerance).
+    assert prev < 1e-2, f"kappa->0 limit too far from Euclidean reference: {prev}"
+
+
+def test_determinism_fixed_seed():
+    """A fixed seed yields identical layer parameters and identical outputs."""
+    pm, X = _make_points(SIGNATURE, n_nodes=8, seed=7)
+    d = X.shape[1]
+
+    torch.manual_seed(123)
+    block_a = StereographicTransformer(pm, num_heads=2, dim=d, head_dim=3).eval()
+    torch.manual_seed(123)
+    block_b = StereographicTransformer(pm, num_heads=2, dim=d, head_dim=3).eval()
+
+    with torch.no_grad():
+        out_a = block_a(X)
+        out_b = block_b(X)
+    assert torch.allclose(
+        out_a, out_b, atol=0.0
+    ), "Same seed must give identical outputs"
+
+
+def test_geometric_linearized_attention_full_matches_masked():
+    """Full-attention fast path equals the all-ones masked path (same kernel attention)."""
+    torch.manual_seed(8)
+    n_heads, n, head_dim = 2, 5, 3
+    Q = torch.randn(n_heads, n, head_dim)
+    K = torch.randn(n_heads, n, head_dim)
+    V = torch.randn(n_heads, n, head_dim)
+
+    attn = GeometricLinearizedAttention(num_heads=n_heads, head_dim=head_dim)
+    out_full = attn(Q, K, V, None)
+    out_ones = attn(Q, K, V, torch.ones(n, n))
+    assert torch.allclose(
+        out_full, out_ones, atol=1e-5
+    ), "None mask should equal an all-ones mask"

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -8,53 +8,35 @@ from manify.predictors.kappa_gcn import KappaGCN, get_A_hat
 from manify.predictors.perceptron import ProductSpacePerceptron
 from manify.predictors.svm import ProductSpaceSVM
 from manify.predictors.transformer import KappaTransformer
-from manify.utils.link_prediction import (
-    make_link_prediction_dataset,
-    split_link_prediction_dataset,
-)
+from manify.utils.link_prediction import make_link_prediction_dataset, split_link_prediction_dataset
 
 
-def _test_base_classifier(
-    model, X_train, X_test, y_train, y_test, task="classification"
-):
+def _test_base_classifier(model, X_train, X_test, y_train, y_test, task="classification"):
     model.fit(X_train, y_train)
 
     preds = model.predict(X_test)
-    assert (
-        preds.shape[0] == X_test.shape[0]
-    ), "Predictions should match the number of test samples"
+    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
 
     if task == "classification":
         probs = model.predict_proba(X_test)
-        assert probs.shape == (
-            X_test.shape[0],
-            2,
-        ), "Probabilities should match the number of test samples and classes"
+        assert probs.shape == (X_test.shape[0], 2), "Probabilities should match the number of test samples and classes"
         assert probs.ndim == 2, "Probabilities should be a 2D array"
-        assert (
-            torch.argmax(probs, dim=1) == preds
-        ).all(), "Predictions should match the class with the highest probability"
+        assert (torch.argmax(probs, dim=1) == preds).all(), (
+            "Predictions should match the class with the highest probability"
+        )
 
         accuracy = (preds == y_test).float().mean()
-        assert (
-            accuracy >= 0.5
-        ), f"Model {model.__class__.__name__} did not achieve sufficient accuracy"
+        assert accuracy >= 0.5, f"Model {model.__class__.__name__} did not achieve sufficient accuracy"
 
         score = model.score(X_test, y_test)
-        assert (
-            score >= 0.5
-        ), f"Model {model.__class__.__name__} did not achieve sufficient score"
-        assert (
-            score == accuracy
-        ), "Score and accuracy should match for classification tasks"
+        assert score >= 0.5, f"Model {model.__class__.__name__} did not achieve sufficient score"
+        assert score == accuracy, "Score and accuracy should match for classification tasks"
     elif task == "regression":
         pass  # No further tests are really possible for regression
 
 
-def _test_kappa_gcn_model(
-    model, X_train, X_test, y_train, y_test, pm, task="classification"
-):
+def _test_kappa_gcn_model(model, X_train, X_test, y_train, y_test, pm, task="classification"):
     X_train_kernel = torch.exp(-pm.pdist2(X_train))
     X_test_kernel = torch.exp(-pm.pdist2(X_test))
     A_train = get_A_hat(X_train_kernel)
@@ -62,57 +44,40 @@ def _test_kappa_gcn_model(
     model.fit(X_train, y_train, A=A_train, use_tqdm=False, epochs=100)
 
     preds = model.predict(X_test, A=A_test)
-    assert (
-        preds.shape[0] == X_test.shape[0]
-    ), "Predictions should match the number of test samples"
+    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
 
     if task == "classification":
         assert preds.ndim == 1, "Predictions should be a 1D array"
 
         probs = model.predict_proba(X_test, A=A_test)
-        assert probs.shape == (
-            X_test.shape[0],
-            2,
-        ), "Probabilities should match the number of test samples and classes"
-        assert (
-            torch.argmax(probs, dim=1) == preds
-        ).all(), "Predictions should match the class with the highest probability"
-        assert (
-            torch.argmax(probs, dim=1).shape[0] == preds.shape[0]
-        ), "The number of predicted classes should match the number of predictions"
+        assert probs.shape == (X_test.shape[0], 2), "Probabilities should match the number of test samples and classes"
+        assert (torch.argmax(probs, dim=1) == preds).all(), (
+            "Predictions should match the class with the highest probability"
+        )
+        assert torch.argmax(probs, dim=1).shape[0] == preds.shape[0], (
+            "The number of predicted classes should match the number of predictions"
+        )
 
         accuracy = (preds == y_test).float().mean()
-        assert (
-            accuracy >= 0.5
-        ), f"Model {model.__class__.__name__} did not achieve sufficient accuracy"
+        assert accuracy >= 0.5, f"Model {model.__class__.__name__} did not achieve sufficient accuracy"
     elif task == "regression":
         assert preds.ndim == 1, "Predictions should be a 1D array"
     elif task == "link_prediction":
         assert preds.ndim == 2, "Link prediction predictions should be a 2D array"
-        assert preds.shape == (
-            X_test.shape[0],
-            X_test.shape[0],
-        ), "Link prediction predictions should match the number of pairs"
-        assert (
-            (preds == 0) | (preds == 1)
-        ).all(), "Link prediction predictions should be binary (0 or 1)"
+        assert preds.shape == (X_test.shape[0], X_test.shape[0]), (
+            "Link prediction predictions should match the number of pairs"
+        )
+        assert ((preds == 0) | (preds == 1)).all(), "Link prediction predictions should be binary (0 or 1)"
 
 
 def test_all_classifiers():
     print("Testing basic classifier functionality")
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
     X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.2, random_state=42, stratify=y
-    )
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42, stratify=y)
 
     # Init models
-    for model_class in [
-        ProductSpaceDT,
-        ProductSpaceRF,
-        ProductSpacePerceptron,
-        ProductSpaceSVM,
-    ]:
+    for model_class in [ProductSpaceDT, ProductSpaceRF, ProductSpacePerceptron, ProductSpaceSVM]:
         print(f"Testing model: {model_class.__name__}")
         model = model_class(pm=pm)
         _test_base_classifier(model, X_train, X_test, y_train, y_test)
@@ -120,17 +85,11 @@ def test_all_classifiers():
     # Kappa-GCN needs its own thing
     pm_stereo, X_train_stereo, X_test_stereo = pm.stereographic(X_train, X_test)
     kappa_gcn = KappaGCN(pm=pm_stereo, output_dim=2, num_hidden=2)
-    _test_kappa_gcn_model(
-        kappa_gcn, X_train_stereo, X_test_stereo, y_train, y_test, pm=pm_stereo
-    )
+    _test_kappa_gcn_model(kappa_gcn, X_train_stereo, X_test_stereo, y_train, y_test, pm=pm_stereo)
 
     # KappaTransformer shares the KappaGCN fit/predict(A=...) interface
-    kappa_transformer = KappaTransformer(
-        pm=pm_stereo, output_dim=2, num_layers=2, num_heads=2, random_state=42
-    )
-    _test_kappa_gcn_model(
-        kappa_transformer, X_train_stereo, X_test_stereo, y_train, y_test, pm=pm_stereo
-    )
+    kappa_transformer = KappaTransformer(pm=pm_stereo, output_dim=2, num_layers=2, num_heads=2, random_state=42)
+    _test_kappa_gcn_model(kappa_transformer, X_train_stereo, X_test_stereo, y_train, y_test, pm=pm_stereo)
 
     print("All classifiers tested successfully.")
 
@@ -138,12 +97,8 @@ def test_all_classifiers():
 def test_all_regressors():
     print("Testing basic regressor functionality")
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
-    X, y = pm.gaussian_mixture(
-        num_points=100, num_classes=2, seed=42, task="regression"
-    )
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.2, random_state=42
-    )
+    X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42, task="regression")
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
     # Init models
     for model_class in [
@@ -153,40 +108,19 @@ def test_all_regressors():
         # ProductSpaceSVM,
     ]:
         model = model_class(pm=pm, task="regression")
-        _test_base_classifier(
-            model, X_train, X_test, y_train, y_test, task="regression"
-        )
+        _test_base_classifier(model, X_train, X_test, y_train, y_test, task="regression")
 
     # Kappa-GCN needs its own thing
     pm_stereo, X_train_stereo, X_test_stereo = pm.stereographic(X_train, X_test)
     kappa_gcn = KappaGCN(pm=pm_stereo, output_dim=1, num_hidden=2, task="regression")
-    _test_kappa_gcn_model(
-        kappa_gcn,
-        X_train_stereo,
-        X_test_stereo,
-        y_train,
-        y_test,
-        pm=pm_stereo,
-        task="regression",
-    )
+    _test_kappa_gcn_model(kappa_gcn, X_train_stereo, X_test_stereo, y_train, y_test, pm=pm_stereo, task="regression")
 
     # KappaTransformer shares the KappaGCN fit/predict(A=...) interface
     kappa_transformer = KappaTransformer(
-        pm=pm_stereo,
-        output_dim=1,
-        num_layers=2,
-        num_heads=2,
-        task="regression",
-        random_state=42,
+        pm=pm_stereo, output_dim=1, num_layers=2, num_heads=2, task="regression", random_state=42
     )
     _test_kappa_gcn_model(
-        kappa_transformer,
-        X_train_stereo,
-        X_test_stereo,
-        y_train,
-        y_test,
-        pm=pm_stereo,
-        task="regression",
+        kappa_transformer, X_train_stereo, X_test_stereo, y_train, y_test, pm=pm_stereo, task="regression"
     )
 
     print("All regressors tested successfully.")
@@ -195,12 +129,8 @@ def test_all_regressors():
 def test_regression_score_is_r2():
     """Regression .score() must return R^2 (higher is better), matching sklearn."""
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
-    X, y = pm.gaussian_mixture(
-        num_points=100, num_classes=2, seed=42, task="regression"
-    )
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.2, random_state=42
-    )
+    X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42, task="regression")
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
     model = ProductSpaceDT(pm=pm, task="regression")
     model.fit(X_train, y_train)
@@ -208,9 +138,7 @@ def test_regression_score_is_r2():
 
     score = model.score(X_test, y_test)
     expected = r2_score(y_test.numpy(), preds.numpy())
-    assert (
-        abs(score - expected) < 1e-5
-    ), f"score {score} should equal r2_score {expected}"
+    assert abs(score - expected) < 1e-5, f"score {score} should equal r2_score {expected}"
     assert score <= 1.0, "R^2 cannot exceed 1.0"
 
 
@@ -227,9 +155,7 @@ def test_get_a_hat_does_not_mutate_input():
 def test_all_link_predictors():
     print("Testing basic link predictor functionality")
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
-    X, _ = pm.gaussian_mixture(
-        num_points=100, num_classes=1, seed=42, task="classification"
-    )
+    X, _ = pm.gaussian_mixture(num_points=100, num_classes=1, seed=42, task="classification")
 
     # Compute adjacency matrix: top 3 neighbors for each node
     with torch.no_grad():
@@ -242,15 +168,11 @@ def test_all_link_predictors():
         adj = ((adj + adj.t()) > 0).float()
 
     # Create link prediction dataset
-    X_lp, y_lp, pm_with_dists = make_link_prediction_dataset(
-        X_embed=X, pm=pm, adj=adj, add_dists=True
-    )
+    X_lp, y_lp, pm_with_dists = make_link_prediction_dataset(X_embed=X, pm=pm, adj=adj, add_dists=True)
 
     # Use split_link_prediction_dataset for train/test split
-    X_train_lp, X_test_lp, y_train_lp, y_test_lp, idx_train, idx_test = (
-        split_link_prediction_dataset(
-            X_lp, y_lp, test_size=0.2, random_state=42, downsample=20
-        )
+    X_train_lp, X_test_lp, y_train_lp, y_test_lp, idx_train, idx_test = split_link_prediction_dataset(
+        X_lp, y_lp, test_size=0.2, random_state=42, downsample=20
     )
 
     # Test traditional models - these treat data as a classification task
@@ -274,17 +196,9 @@ def test_all_link_predictors():
     pm_stereo, X_train_stereo, X_test_stereo = pm.stereographic(X_train, X_test)
 
     # Test KappaGCN
-    kappa_gcn = KappaGCN(
-        pm=pm_stereo, output_dim=2, num_hidden=2, task="link_prediction"
-    )
+    kappa_gcn = KappaGCN(pm=pm_stereo, output_dim=2, num_hidden=2, task="link_prediction")
     _test_kappa_gcn_model(
-        kappa_gcn,
-        X_train_stereo,
-        X_test_stereo,
-        adj_train,
-        adj_test,
-        pm=pm_stereo,
-        task="link_prediction",
+        kappa_gcn, X_train_stereo, X_test_stereo, adj_train, adj_test, pm=pm_stereo, task="link_prediction"
     )
     print("All link predictors tested successfully.")
 
@@ -292,111 +206,77 @@ def test_all_link_predictors():
 def test_random_forest_batch():
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
     X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.2, random_state=42
-    )
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
     batch_sizes = [1, 10, None]
     preds_list = []
 
     for batch_size in batch_sizes:
-        rf = ProductSpaceRF(
-            pm=pm,
-            batch_size=batch_size,
-            n_estimators=2,
-            random_state=42,
-            max_features="none",
-        )
+        rf = ProductSpaceRF(pm=pm, batch_size=batch_size, n_estimators=2, random_state=42, max_features="none")
         rf.fit(X_train, y_train)
         preds = rf.predict(X_test)
-        assert (
-            preds.shape[0] == X_test.shape[0]
-        ), "Predictions should match the number of test samples"
+        assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
         assert preds.ndim == 1, "Predictions should be a 1D array"
-        assert (
-            preds == y_test
-        ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+        assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
         preds_list.append(preds)
 
     # Check equality for all outputs
     for i in range(len(preds_list)):
         for j in range(i + 1, len(preds_list)):
-            assert torch.allclose(
-                preds_list[i], preds_list[j]
-            ), f"Predictions should be the same for batch sizes {batch_sizes[i]} and {batch_sizes[j]}"
+            assert torch.allclose(preds_list[i], preds_list[j]), (
+                f"Predictions should be the same for batch sizes {batch_sizes[i]} and {batch_sizes[j]}"
+            )
 
 
 def test_decision_tree_special_dims_ablate_midpoints():
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
     X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.2, random_state=42
-    )
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
     # Special dims
     rf = ProductSpaceRF(pm=pm, use_special_dims=True, n_estimators=2, random_state=42)
     rf.fit(X_train, y_train)
     preds = rf.predict(X_test)
-    assert (
-        preds.shape[0] == X_test.shape[0]
-    ), "Predictions should match the number of test samples"
+    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
-    assert (
-        preds == y_test
-    ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+    assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
 
     # Ablate midpoints
     rf = ProductSpaceRF(pm=pm, ablate_midpoints=True, n_estimators=2, random_state=42)
     rf.fit(X_train, y_train)
     preds = rf.predict(X_test)
-    assert (
-        preds.shape[0] == X_test.shape[0]
-    ), "Predictions should match the number of test samples"
+    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
-    assert (
-        preds == y_test
-    ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+    assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
 
 
 def test_random_forest_max_features():
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
     X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.2, random_state=42
-    )
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
     # max_features = sqrt
     dt = ProductSpaceRF(pm=pm, max_features="sqrt", n_estimators=2)
     dt.fit(X_train, y_train)
     preds = dt.predict(X_test)
-    assert (
-        preds.shape[0] == X_test.shape[0]
-    ), "Predictions should match the number of test samples"
+    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
-    assert (
-        preds == y_test
-    ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+    assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
 
     # max_features = log2
     dt = ProductSpaceRF(pm=pm, max_features="log2", n_estimators=2)
     dt.fit(X_train, y_train)
     preds = dt.predict(X_test)
-    assert (
-        preds.shape[0] == X_test.shape[0]
-    ), "Predictions should match the number of test samples"
+    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
-    assert (
-        preds == y_test
-    ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+    assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
 
     # max_features = int: each tree should subsample exactly that many feature columns
     n_features_int = 3
     rf = ProductSpaceRF(pm=pm, max_features=n_features_int, n_estimators=2)
     rf.fit(X_train, y_train)
     n_cols = rf.trees[0].permutations.shape[0]
-    assert (
-        n_cols == n_features_int
-    ), f"Expected {n_features_int} subsampled features, got {n_cols}"
+    assert n_cols == n_features_int, f"Expected {n_features_int} subsampled features, got {n_cols}"
     assert all(tree.permutations.shape[0] == n_features_int for tree in rf.trees)
 
     # max_features larger than the available columns should clamp to the number of columns

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -7,35 +7,54 @@ from manify.predictors.decision_tree import ProductSpaceDT, ProductSpaceRF
 from manify.predictors.kappa_gcn import KappaGCN, get_A_hat
 from manify.predictors.perceptron import ProductSpacePerceptron
 from manify.predictors.svm import ProductSpaceSVM
-from manify.utils.link_prediction import make_link_prediction_dataset, split_link_prediction_dataset
+from manify.predictors.transformer import KappaTransformer
+from manify.utils.link_prediction import (
+    make_link_prediction_dataset,
+    split_link_prediction_dataset,
+)
 
 
-def _test_base_classifier(model, X_train, X_test, y_train, y_test, task="classification"):
+def _test_base_classifier(
+    model, X_train, X_test, y_train, y_test, task="classification"
+):
     model.fit(X_train, y_train)
 
     preds = model.predict(X_test)
-    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
+    assert (
+        preds.shape[0] == X_test.shape[0]
+    ), "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
 
     if task == "classification":
         probs = model.predict_proba(X_test)
-        assert probs.shape == (X_test.shape[0], 2), "Probabilities should match the number of test samples and classes"
+        assert probs.shape == (
+            X_test.shape[0],
+            2,
+        ), "Probabilities should match the number of test samples and classes"
         assert probs.ndim == 2, "Probabilities should be a 2D array"
-        assert (torch.argmax(probs, dim=1) == preds).all(), (
-            "Predictions should match the class with the highest probability"
-        )
+        assert (
+            torch.argmax(probs, dim=1) == preds
+        ).all(), "Predictions should match the class with the highest probability"
 
         accuracy = (preds == y_test).float().mean()
-        assert accuracy >= 0.5, f"Model {model.__class__.__name__} did not achieve sufficient accuracy"
+        assert (
+            accuracy >= 0.5
+        ), f"Model {model.__class__.__name__} did not achieve sufficient accuracy"
 
         score = model.score(X_test, y_test)
-        assert score >= 0.5, f"Model {model.__class__.__name__} did not achieve sufficient score"
-        assert score == accuracy, "Score and accuracy should match for classification tasks"
+        assert (
+            score >= 0.5
+        ), f"Model {model.__class__.__name__} did not achieve sufficient score"
+        assert (
+            score == accuracy
+        ), "Score and accuracy should match for classification tasks"
     elif task == "regression":
         pass  # No further tests are really possible for regression
 
 
-def _test_kappa_gcn_model(model, X_train, X_test, y_train, y_test, pm, task="classification"):
+def _test_kappa_gcn_model(
+    model, X_train, X_test, y_train, y_test, pm, task="classification"
+):
     X_train_kernel = torch.exp(-pm.pdist2(X_train))
     X_test_kernel = torch.exp(-pm.pdist2(X_test))
     A_train = get_A_hat(X_train_kernel)
@@ -43,22 +62,29 @@ def _test_kappa_gcn_model(model, X_train, X_test, y_train, y_test, pm, task="cla
     model.fit(X_train, y_train, A=A_train, use_tqdm=False, epochs=100)
 
     preds = model.predict(X_test, A=A_test)
-    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
+    assert (
+        preds.shape[0] == X_test.shape[0]
+    ), "Predictions should match the number of test samples"
 
     if task == "classification":
         assert preds.ndim == 1, "Predictions should be a 1D array"
 
         probs = model.predict_proba(X_test, A=A_test)
-        assert probs.shape == (X_test.shape[0], 2), "Probabilities should match the number of test samples and classes"
-        assert (torch.argmax(probs, dim=1) == preds).all(), (
-            "Predictions should match the class with the highest probability"
-        )
-        assert torch.argmax(probs, dim=1).shape[0] == preds.shape[0], (
-            "The number of predicted classes should match the number of predictions"
-        )
+        assert probs.shape == (
+            X_test.shape[0],
+            2,
+        ), "Probabilities should match the number of test samples and classes"
+        assert (
+            torch.argmax(probs, dim=1) == preds
+        ).all(), "Predictions should match the class with the highest probability"
+        assert (
+            torch.argmax(probs, dim=1).shape[0] == preds.shape[0]
+        ), "The number of predicted classes should match the number of predictions"
 
         accuracy = (preds == y_test).float().mean()
-        assert accuracy >= 0.5, f"Model {model.__class__.__name__} did not achieve sufficient accuracy"
+        assert (
+            accuracy >= 0.5
+        ), f"Model {model.__class__.__name__} did not achieve sufficient accuracy"
     elif task == "regression":
         assert preds.ndim == 1, "Predictions should be a 1D array"
     elif task == "link_prediction":
@@ -67,14 +93,18 @@ def _test_kappa_gcn_model(model, X_train, X_test, y_train, y_test, pm, task="cla
             X_test.shape[0],
             X_test.shape[0],
         ), "Link prediction predictions should match the number of pairs"
-        assert ((preds == 0) | (preds == 1)).all(), "Link prediction predictions should be binary (0 or 1)"
+        assert (
+            (preds == 0) | (preds == 1)
+        ).all(), "Link prediction predictions should be binary (0 or 1)"
 
 
 def test_all_classifiers():
     print("Testing basic classifier functionality")
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
     X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42, stratify=y)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42, stratify=y
+    )
 
     # Init models
     for model_class in [
@@ -90,7 +120,17 @@ def test_all_classifiers():
     # Kappa-GCN needs its own thing
     pm_stereo, X_train_stereo, X_test_stereo = pm.stereographic(X_train, X_test)
     kappa_gcn = KappaGCN(pm=pm_stereo, output_dim=2, num_hidden=2)
-    _test_kappa_gcn_model(kappa_gcn, X_train_stereo, X_test_stereo, y_train, y_test, pm=pm_stereo)
+    _test_kappa_gcn_model(
+        kappa_gcn, X_train_stereo, X_test_stereo, y_train, y_test, pm=pm_stereo
+    )
+
+    # KappaTransformer shares the KappaGCN fit/predict(A=...) interface
+    kappa_transformer = KappaTransformer(
+        pm=pm_stereo, output_dim=2, num_layers=2, num_heads=2, random_state=42
+    )
+    _test_kappa_gcn_model(
+        kappa_transformer, X_train_stereo, X_test_stereo, y_train, y_test, pm=pm_stereo
+    )
 
     print("All classifiers tested successfully.")
 
@@ -98,8 +138,12 @@ def test_all_classifiers():
 def test_all_regressors():
     print("Testing basic regressor functionality")
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
-    X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42, task="regression")
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    X, y = pm.gaussian_mixture(
+        num_points=100, num_classes=2, seed=42, task="regression"
+    )
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
 
     # Init models
     for model_class in [
@@ -109,12 +153,41 @@ def test_all_regressors():
         # ProductSpaceSVM,
     ]:
         model = model_class(pm=pm, task="regression")
-        _test_base_classifier(model, X_train, X_test, y_train, y_test, task="regression")
+        _test_base_classifier(
+            model, X_train, X_test, y_train, y_test, task="regression"
+        )
 
     # Kappa-GCN needs its own thing
     pm_stereo, X_train_stereo, X_test_stereo = pm.stereographic(X_train, X_test)
     kappa_gcn = KappaGCN(pm=pm_stereo, output_dim=1, num_hidden=2, task="regression")
-    _test_kappa_gcn_model(kappa_gcn, X_train_stereo, X_test_stereo, y_train, y_test, pm=pm_stereo, task="regression")
+    _test_kappa_gcn_model(
+        kappa_gcn,
+        X_train_stereo,
+        X_test_stereo,
+        y_train,
+        y_test,
+        pm=pm_stereo,
+        task="regression",
+    )
+
+    # KappaTransformer shares the KappaGCN fit/predict(A=...) interface
+    kappa_transformer = KappaTransformer(
+        pm=pm_stereo,
+        output_dim=1,
+        num_layers=2,
+        num_heads=2,
+        task="regression",
+        random_state=42,
+    )
+    _test_kappa_gcn_model(
+        kappa_transformer,
+        X_train_stereo,
+        X_test_stereo,
+        y_train,
+        y_test,
+        pm=pm_stereo,
+        task="regression",
+    )
 
     print("All regressors tested successfully.")
 
@@ -122,8 +195,12 @@ def test_all_regressors():
 def test_regression_score_is_r2():
     """Regression .score() must return R^2 (higher is better), matching sklearn."""
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
-    X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42, task="regression")
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    X, y = pm.gaussian_mixture(
+        num_points=100, num_classes=2, seed=42, task="regression"
+    )
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
 
     model = ProductSpaceDT(pm=pm, task="regression")
     model.fit(X_train, y_train)
@@ -131,7 +208,9 @@ def test_regression_score_is_r2():
 
     score = model.score(X_test, y_test)
     expected = r2_score(y_test.numpy(), preds.numpy())
-    assert abs(score - expected) < 1e-5, f"score {score} should equal r2_score {expected}"
+    assert (
+        abs(score - expected) < 1e-5
+    ), f"score {score} should equal r2_score {expected}"
     assert score <= 1.0, "R^2 cannot exceed 1.0"
 
 
@@ -148,7 +227,9 @@ def test_get_a_hat_does_not_mutate_input():
 def test_all_link_predictors():
     print("Testing basic link predictor functionality")
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
-    X, _ = pm.gaussian_mixture(num_points=100, num_classes=1, seed=42, task="classification")
+    X, _ = pm.gaussian_mixture(
+        num_points=100, num_classes=1, seed=42, task="classification"
+    )
 
     # Compute adjacency matrix: top 3 neighbors for each node
     with torch.no_grad():
@@ -161,11 +242,15 @@ def test_all_link_predictors():
         adj = ((adj + adj.t()) > 0).float()
 
     # Create link prediction dataset
-    X_lp, y_lp, pm_with_dists = make_link_prediction_dataset(X_embed=X, pm=pm, adj=adj, add_dists=True)
+    X_lp, y_lp, pm_with_dists = make_link_prediction_dataset(
+        X_embed=X, pm=pm, adj=adj, add_dists=True
+    )
 
     # Use split_link_prediction_dataset for train/test split
-    X_train_lp, X_test_lp, y_train_lp, y_test_lp, idx_train, idx_test = split_link_prediction_dataset(
-        X_lp, y_lp, test_size=0.2, random_state=42, downsample=20
+    X_train_lp, X_test_lp, y_train_lp, y_test_lp, idx_train, idx_test = (
+        split_link_prediction_dataset(
+            X_lp, y_lp, test_size=0.2, random_state=42, downsample=20
+        )
     )
 
     # Test traditional models - these treat data as a classification task
@@ -189,7 +274,9 @@ def test_all_link_predictors():
     pm_stereo, X_train_stereo, X_test_stereo = pm.stereographic(X_train, X_test)
 
     # Test KappaGCN
-    kappa_gcn = KappaGCN(pm=pm_stereo, output_dim=2, num_hidden=2, task="link_prediction")
+    kappa_gcn = KappaGCN(
+        pm=pm_stereo, output_dim=2, num_hidden=2, task="link_prediction"
+    )
     _test_kappa_gcn_model(
         kappa_gcn,
         X_train_stereo,
@@ -205,77 +292,111 @@ def test_all_link_predictors():
 def test_random_forest_batch():
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
     X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
 
     batch_sizes = [1, 10, None]
     preds_list = []
 
     for batch_size in batch_sizes:
-        rf = ProductSpaceRF(pm=pm, batch_size=batch_size, n_estimators=2, random_state=42, max_features="none")
+        rf = ProductSpaceRF(
+            pm=pm,
+            batch_size=batch_size,
+            n_estimators=2,
+            random_state=42,
+            max_features="none",
+        )
         rf.fit(X_train, y_train)
         preds = rf.predict(X_test)
-        assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
+        assert (
+            preds.shape[0] == X_test.shape[0]
+        ), "Predictions should match the number of test samples"
         assert preds.ndim == 1, "Predictions should be a 1D array"
-        assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+        assert (
+            preds == y_test
+        ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
         preds_list.append(preds)
 
     # Check equality for all outputs
     for i in range(len(preds_list)):
         for j in range(i + 1, len(preds_list)):
-            assert torch.allclose(preds_list[i], preds_list[j]), (
-                f"Predictions should be the same for batch sizes {batch_sizes[i]} and {batch_sizes[j]}"
-            )
+            assert torch.allclose(
+                preds_list[i], preds_list[j]
+            ), f"Predictions should be the same for batch sizes {batch_sizes[i]} and {batch_sizes[j]}"
 
 
 def test_decision_tree_special_dims_ablate_midpoints():
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
     X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
 
     # Special dims
     rf = ProductSpaceRF(pm=pm, use_special_dims=True, n_estimators=2, random_state=42)
     rf.fit(X_train, y_train)
     preds = rf.predict(X_test)
-    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
+    assert (
+        preds.shape[0] == X_test.shape[0]
+    ), "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
-    assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+    assert (
+        preds == y_test
+    ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
 
     # Ablate midpoints
     rf = ProductSpaceRF(pm=pm, ablate_midpoints=True, n_estimators=2, random_state=42)
     rf.fit(X_train, y_train)
     preds = rf.predict(X_test)
-    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
+    assert (
+        preds.shape[0] == X_test.shape[0]
+    ), "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
-    assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+    assert (
+        preds == y_test
+    ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
 
 
 def test_random_forest_max_features():
     pm = ProductManifold(signature=[(-1.0, 2), (0.0, 2), (1.0, 2)])
     X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
 
     # max_features = sqrt
     dt = ProductSpaceRF(pm=pm, max_features="sqrt", n_estimators=2)
     dt.fit(X_train, y_train)
     preds = dt.predict(X_test)
-    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
+    assert (
+        preds.shape[0] == X_test.shape[0]
+    ), "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
-    assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+    assert (
+        preds == y_test
+    ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
 
     # max_features = log2
     dt = ProductSpaceRF(pm=pm, max_features="log2", n_estimators=2)
     dt.fit(X_train, y_train)
     preds = dt.predict(X_test)
-    assert preds.shape[0] == X_test.shape[0], "Predictions should match the number of test samples"
+    assert (
+        preds.shape[0] == X_test.shape[0]
+    ), "Predictions should match the number of test samples"
     assert preds.ndim == 1, "Predictions should be a 1D array"
-    assert (preds == y_test).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
+    assert (
+        preds == y_test
+    ).float().mean() >= 0.5, "Model did not achieve sufficient accuracy"
 
     # max_features = int: each tree should subsample exactly that many feature columns
     n_features_int = 3
     rf = ProductSpaceRF(pm=pm, max_features=n_features_int, n_estimators=2)
     rf.fit(X_train, y_train)
     n_cols = rf.trees[0].permutations.shape[0]
-    assert n_cols == n_features_int, f"Expected {n_features_int} subsampled features, got {n_cols}"
+    assert (
+        n_cols == n_features_int
+    ), f"Expected {n_features_int} subsampled features, got {n_cols}"
     assert all(tree.permutations.shape[0] == n_features_int for tree in rf.trees)
 
     # max_features larger than the available columns should clamp to the number of columns


### PR DESCRIPTION
Makes the experimental stereographic transformer layers actually work and implements them faithfully to **"Curve Your Attention: Mixed-Curvature Transformers" (FPS-T, arXiv:2309.04082)** — the paper those layers were originally based on. Adds a predictor wrapper and benchmark integration.

## Background
The transformer layers (`StereographicLayerNorm`, `GeometricLinearizedAttention`, `StereographicAttention`, `StereographicTransformer`) had **no test coverage and did not run** — three distinct shape/init bugs threw on the first forward pass.

## What changed
- **Fixed the 3 bugs** so the layers run on the library's single-graph `[n_nodes, dim]` convention (mask = adjacency; `None` = full attention).
- **Faithful gyrovector attention** (not tangent-space):
  - Scores (Eq 6, kernelized Eq 11): parallel-transport Q,K to the origin, `φ(x)=ELU(x)+1`.
  - **Aggregation = Einstein midpoint** (Eq 7) via conformal factors `λ` + `½⊗_κ` — the geometric aggregation, *not* a Euclidean mean.
  - **Per-head learnable curvatures** (`nn.Parameter[num_heads]`); MHA output is the product over heads (Eq 8).
  - Q/K/V projected in the tangent space at the origin (paper-allowed, Eq 5) to sidestep geoopt's dimension-preserving `mobius_matvec`.
- **`KappaTransformer`** predictor (`manify/predictors/transformer.py`): stacks `StereographicTransformer` blocks → `StereographicLogits` head; `fit/predict/predict_proba(A=…)` like `KappaGCN`; classification + regression. Exported from `manify` and `manify.predictors`.
- **Benchmark integration**: `kappa_transformer` model key, runs alongside `kappa_gcn`.

## Tests (`tests/test_nn_layers.py`, +predictor cases)
Smoke/shape, on-manifold validity, **permutation-equivariance** (full mask), masking-blocks-influence, gradient finiteness, **κ→0 → Euclidean limit**, determinism, None==ones-mask, brute-force-midpoint match, and the key guard: **aggregation is the gyromidpoint, not the arithmetic mean** (differs 1.6e-2 at κ=1, → 1.5e-6 at κ=1e-4). **19 passed**; ruff clean on `manify/`.

## Notes / limitations
- Q/K/V projections are tangent-space linear maps (paper-allowed); only the *aggregation* is gyrovector.
- The block needs **≥2 layers** to be competitive (a single attention+residual barely moves signal); the `KappaTransformer` default is `num_layers=2` and the benchmark uses `max(2, …)`.
- It learns competitively with `kappa_gcn` in smoke runs (binary 0.75–0.83; beats GCN on one seed).