### PR TITLE
Fix dataloader test crashing under stale HF offline cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,7 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run dataloader tests
-        run: pytest tests/test_utils.py::test_dataloaders -v --cov=manify/dataloaders --cov-report=xml
+        run: pytest tests/test_utils.py::test_dataloaders -v --cov=manify.utils.dataloaders --cov-report=xml
 
       # Upload dataloader coverage separately
       - name: Upload dataloader coverage to Codecov

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,19 @@
 """Shared pytest fixtures and configuration for the manify test suite.
 
-This module centralizes Hugging Face dataset handling so that:
+Centralizes Hugging Face dataset handling so that:
 
-1. The on-disk Hugging Face cache is reused across tests and across CI runs. When a cache
-   is already populated (locally or restored by ``actions/cache`` in CI), we flip
-   ``datasets`` into offline mode so that no per-dataset network round-trip (revision /
-   metadata check) is performed. With ``datasets >= 2`` an online ``load_dataset`` call
-   costs ~1-1.5s per dataset *even when fully cached* and is subject to unauthenticated
-   Hub rate limiting; offline reuse of the same cache is ~0.1s and never flakes.
+1. The on-disk HF cache is reused across tests and CI runs. When *every* manify
+   dataset is already cached (locally or restored by ``actions/cache``), we flip
+   ``datasets`` into offline mode to skip the ~1-1.5s per-dataset Hub round-trip
+   (revision/metadata check) and the unauthenticated rate-limit flakiness.
 
-2. ``load_hf`` results are memoized within a run (see ``manify.utils.dataloaders``), so a
-   dataset requested by several tests is only decoded once.
+2. ``load_hf`` results are memoized within a run (see ``manify.utils.dataloaders``).
 
-The offline switch is conditional: if the expected datasets are not present in the cache
-(e.g. a cold CI run before the cache exists), we leave ``datasets`` online so the first run
-can populate the cache, which ``actions/cache`` then saves for subsequent runs.
+Offline mode is only safe when the cache is **fully** warm: under offline mode a
+requested-but-missing dataset hard-fails (``ConnectionError: OfflineModeIsEnabled``).
+So we require ALL expected datasets to be present before going offline; otherwise we
+force ONLINE — even if CI exported ``HF_HUB_OFFLINE`` on an incomplete cache — so the
+run can fetch (and populate) whatever is missing. Correctness over speed.
 """
 
 from __future__ import annotations
@@ -24,9 +23,8 @@ from pathlib import Path
 
 import pytest
 
-# Datasets pulled by the test suite via ``load_hf`` (namespace ``manify``). Kept in sync with
-# tests/test_utils.py::test_dataloaders and the load_hf calls in other test modules. Used both
-# to detect whether the local cache is warm and to pre-warm/memoize datasets for the session.
+# Datasets pulled by the suite via ``load_hf`` (namespace ``manify``). Keep in sync with
+# tests/test_utils.py::test_dataloaders and load_hf calls elsewhere.
 _HF_DATASETS: tuple[str, ...] = (
     "cities",
     "cs_phds",
@@ -53,12 +51,7 @@ _HF_DATASETS: tuple[str, ...] = (
 
 
 def _hf_home() -> Path:
-    """Return the Hugging Face home directory that ``datasets`` will actually use.
-
-    Honors ``HF_HOME`` if set, otherwise falls back to the platform default
-    (``~/.cache/huggingface``). This mirrors how ``huggingface_hub`` resolves the cache root,
-    so the path we probe is the same one ``load_dataset`` reads and writes.
-    """
+    """HF home dir that ``datasets`` will actually use (honors ``HF_HOME``)."""
     hf_home = os.environ.get("HF_HOME")
     if hf_home:
         return Path(hf_home)
@@ -67,62 +60,56 @@ def _hf_home() -> Path:
     return base / "huggingface"
 
 
-def _cache_is_warm() -> bool:
-    """Heuristically determine whether the manify datasets are already cached on disk.
+def _cache_is_fully_warm() -> bool:
+    """True only if EVERY manify dataset is present in the on-disk hub cache.
 
-    We consider the cache warm if the ``hub`` cache directory contains entries for the manify
-    datasets. This is intentionally lenient: any cached manify dataset flips us to offline mode,
-    because a partial cache plus offline mode still avoids network round-trips for the cached
-    datasets, and ``datasets`` will raise clearly if a genuinely-missing dataset is requested.
+    Strict on purpose: a partial cache + offline mode hard-fails on the first
+    missing dataset, so offline is only safe once all of them are cached.
     """
     hub_dir = _hf_home() / "hub"
     if not hub_dir.is_dir():
         return False
-    return any(p.name.startswith("datasets--manify--") for p in hub_dir.iterdir())
+    cached = {p.name for p in hub_dir.iterdir() if p.is_dir()}
+    return all(f"datasets--manify--{name}" in cached for name in _HF_DATASETS)
 
 
-@pytest.fixture(scope="session", autouse=True)
-def hf_offline_when_cached() -> None:
-    """Enable Hugging Face offline mode for the session when the dataset cache is warm.
+def _set_offline_runtime(offline: bool) -> None:
+    """Flip ``datasets``/``huggingface_hub`` offline flags at runtime (both directions).
 
-    Setting ``HF_HUB_OFFLINE`` / ``HF_DATASETS_OFFLINE`` makes ``datasets.load_dataset`` serve
-    the manify datasets directly from the local cache with no network access, eliminating the
-    per-dataset revision check (~1-1.5s each) and Hub rate-limit flakiness. If the cache is cold
-    (no manify datasets present), we stay online so the first run can download and populate it.
-
-    An explicit ``HF_HUB_OFFLINE`` already set in the environment (e.g. by CI after a cache hit)
-    is always respected and never overridden.
-    """
-    if os.environ.get("HF_HUB_OFFLINE") is not None:
-        # Caller (e.g. CI) has already decided; respect it. CI sets this before the test process
-        # starts, so the library reads it at import time and no runtime patching is needed.
-        return
-    if _cache_is_warm():
-        os.environ["HF_HUB_OFFLINE"] = "1"
-        os.environ["HF_DATASETS_OFFLINE"] = "1"
-        _force_offline_runtime()
-
-
-def _force_offline_runtime() -> None:
-    """Flip ``datasets``/``huggingface_hub`` into offline mode at runtime.
-
-    ``datasets`` and ``huggingface_hub`` read ``HF_HUB_OFFLINE`` into module-level config at
-    import time. Since ``datasets`` is already imported (via ``manify.utils.dataloaders``) by the
-    time this session fixture runs, setting the environment variable alone is too late. We also
-    patch the already-loaded config objects so ``load_dataset`` actually serves from the local
-    cache without any network access. This is best-effort across library versions.
+    These libs read ``HF_HUB_OFFLINE`` into module-level config at import time, and
+    ``datasets`` is already imported (via ``manify.utils.dataloaders``) before this
+    session fixture runs, so setting the env var alone is too late in either direction.
+    Best-effort across library versions.
     """
     try:
-        import datasets.config as ds_config  # noqa: PLC0415 - patch the already-imported config
+        import datasets.config as ds_config  # noqa: PLC0415 - patch already-imported config
 
-        ds_config.HF_HUB_OFFLINE = True
+        ds_config.HF_HUB_OFFLINE = offline
         if hasattr(ds_config, "HF_DATASETS_OFFLINE"):
-            ds_config.HF_DATASETS_OFFLINE = True
+            ds_config.HF_DATASETS_OFFLINE = offline
     except Exception:  # noqa: BLE001 - offline mode is an optimization, never fatal
         pass
     try:
         import huggingface_hub.constants as hub_constants  # noqa: PLC0415 - patch loaded config
 
-        hub_constants.HF_HUB_OFFLINE = True
+        hub_constants.HF_HUB_OFFLINE = offline
     except Exception:  # noqa: BLE001
         pass
+
+
+@pytest.fixture(scope="session", autouse=True)
+def hf_offline_when_cached() -> None:
+    """Enable HF offline mode for the session only when the cache is fully warm.
+
+    Fully warm -> go offline (fast, no Hub round-trips). Otherwise force ONLINE,
+    overriding any ``HF_HUB_OFFLINE`` the environment/CI may have set on an incomplete
+    cache, so missing datasets can be downloaded instead of hard-failing.
+    """
+    offline = _cache_is_fully_warm()
+    if offline:
+        os.environ["HF_HUB_OFFLINE"] = "1"
+        os.environ["HF_DATASETS_OFFLINE"] = "1"
+    else:
+        os.environ.pop("HF_HUB_OFFLINE", None)
+        os.environ.pop("HF_DATASETS_OFFLINE", None)
+    _set_offline_runtime(offline)


### PR DESCRIPTION
`test_dataloaders` was failing in CI with:
```
ConnectionError: Couldn't reach 'manify/cities' on the Hub (OfflineModeIsEnabled)
```

## Cause
The HF-caching optimization (PR #34) enabled **offline mode too eagerly**:
- `conftest._cache_is_warm()` returned `True` if *any* manify dataset was cached (lenient), and
- the fixture blindly honored an env-set `HF_HUB_OFFLINE` (which the workflow exports on `cache-hit`).

On a partial/stale cache that's fatal: under offline mode, a requested-but-missing dataset (`manify/cities`) hard-fails instead of falling back to the Hub. The conftest's bet that "datasets will raise clearly" was right — it raised, and broke the test.

## Fix (`tests/conftest.py`)
- Go offline **only when every expected dataset is present** on disk (`_cache_is_fully_warm`, strict).
- Otherwise **force ONLINE at runtime**, overriding any `HF_HUB_OFFLINE` the environment/CI set on an incomplete cache, so the run downloads (and repopulates) whatever is missing.
- `_set_offline_runtime(bool)` now flips the `datasets`/`huggingface_hub` config in **both** directions (the old code only forced offline).

Net: offline is used only when it's safe (full cache → fast); any incomplete cache degrades to online (correct, slightly slower) instead of crashing.

## Also
- Fix the wrong coverage target in the dataloaders job: `--cov=manify/dataloaders` → `--cov=manify.utils.dataloaders` (was emitting "module never imported / no data collected" warnings and an empty report).

## Validation (local)
- Fully-warm cache → offline path → `test_dataloaders` **passes** offline.
- Simulated incomplete cache **with `HF_HUB_OFFLINE=1` set** → fixture forces online (`HF_HUB_OFFLINE` unset, `datasets.config.HF_HUB_OFFLINE=False`) → no crash.