### PR TITLE
Fix CI segfault in dataloader job (coverage module-name target)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,7 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run dataloader tests
-        run: pytest tests/test_utils.py::test_dataloaders -v --cov=manify.utils.dataloaders --cov-report=xml
+        run: pytest tests/test_utils.py::test_dataloaders -v --cov=manify/utils/dataloaders.py --cov-report=xml
 
       # Upload dataloader coverage separately
       - name: Upload dataloader coverage to Codecov


### PR DESCRIPTION
`main` CI is red: the **test-dataloaders** job exits **139 (SIGSEGV)** during collection (the `test (3.10–3.13)` jobs pass). Reproduced locally:
```
ERROR tests/test_utils.py - SystemError: () method: bad call flags
```

## Cause
PR #38 corrected the dataloader job's coverage target from the (wrong, harmless) `--cov=manify/dataloaders` to the dotted **module name** `--cov=manify.utils.dataloaders`. With the current stack (coverage 7.14, datasets 5.0, torch 2.12), coverage importing that module **under its C tracer** crashes with `SystemError: () method: bad call flags` → SIGSEGV in CI.

Isolation (collect-only, local):
- `--cov=manify.utils.dataloaders` (dotted module) → **crash**
- `--cov` (whole project, as the main job uses) → ok
- `--cov=manify` (package) → ok
- `--cov=manify/utils/dataloaders.py` (file path) → ok

The dotted-module form makes coverage import-under-trace; the file-path form just maps the file. The main `test` job uses whole-project `--cov`, so it was never affected.

## Fix
Use the **file path**: `--cov=manify/utils/dataloaders.py`. Measures the same file, no crash.

## Verified locally
- Collection clean (no `SystemError`).
- Full run: **1 passed** in ~172s, `--cov-report=xml` generated.