### PR TITLE
Ignore mkdocs build output (site/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage.xml
 settings.json
 prof/
 venv
+site/


### PR DESCRIPTION
Cherry-picks the `.gitignore` addition of `site/` (mkdocs build output) from #24.

Co-authored-by: richarddushime <mudaherarich@gmail.com>

See #24 — the rest of that PR (index/installation/contributing pages, a pinned `docs/requirement.txt`, and a hand-curated API-reference nav) duplicates the README/CONTRIBUTING.md and the auto-generated API reference, so we're keeping the docs site pointed at those single sources of truth and taking just this clean, zero-maintenance bit.