### PR TITLE
Fix sampling on stereographic manifolds (#37)

### DIFF
--- a/manify/manifolds.py
+++ b/manify/manifolds.py
@@ -205,6 +205,14 @@ class Manifold:
             tangent_points: Tensor of points in the tangent plane at the origin.
         """
         x = torch.Tensor(x).reshape(-1, self.dim)
+        if self.is_stereographic:
+            # Stereographic models keep the intrinsic dimension (ambient_dim == dim), so there is no
+            # extra coordinate to prepend. The conformal factor at the origin is
+            # lambda_0 = 2 / (1 + curvature * ||0||^2) = 2 (for every curvature, including the flat
+            # case), so we divide the orthonormal tangent vector by lambda_0 to express it in
+            # stereographic coordinates and recover a correctly scaled wrapped-normal sample
+            # (matching the equivalent non-stereographic manifold).
+            return x / 2.0
         if self.type == "E":
             return x
         return torch.cat([torch.zeros((x.shape[0], 1), device=self.device), x], dim=1)

--- a/tests/test_manifolds.py
+++ b/tests/test_manifolds.py
@@ -391,3 +391,53 @@ def test_sampling_edge_cases():
     large_Sigma = torch.eye(m.dim) * 10.0
     samples_large = m.sample(n_samples=100, z_mean=mu, sigma=large_Sigma)
     assert samples_large.shape == (100, m.ambient_dim), "Sampling failed for large covariance"
+
+
+def test_stereographic_sampling():
+    """Regression test for sampling on stereographic manifolds (see issue #37).
+
+    Sampling on stereographic manifolds used to crash because the intrinsic tangent vector was
+    embedded with an extra ambient coordinate (correct for the Lorentz/sphere models, but wrong
+    for stereographic coordinates where ambient_dim == dim). This verifies that sampling now (a)
+    runs and lands on the manifold, and (b) produces the same wrapped-normal distribution as the
+    equivalent non-stereographic manifold (distances to the origin are an intrinsic quantity).
+    """
+    print("Testing sampling on stereographic manifolds...")
+
+    curvatures = [-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0]
+
+    # Single stereographic manifolds: no crash, points on manifold, distribution matches reference
+    quantiles = torch.tensor([0.25, 0.5, 0.75, 0.9])
+    for K in curvatures:
+        print(f"  Testing curvature K = {K}")
+        m_stereo = Manifold(K, 4, stereographic=True)
+        assert m_stereo.is_stereographic
+
+        torch.manual_seed(42)
+        samples = m_stereo.sample(100)
+        assert samples.shape == (100, m_stereo.ambient_dim), f"Sample shape mismatch for stereographic K={K}"
+        assert m_stereo.manifold.check_point(samples), f"Stereographic samples not on manifold for K={K}"
+
+        # Wrapped-normal distance-to-origin should match the non-stereographic manifold of the same curvature
+        m_ref = Manifold(K, 4, stereographic=False)
+        torch.manual_seed(0)
+        d_ref = m_ref.dist(m_ref.sample(20000), m_ref.mu0).flatten()
+        torch.manual_seed(0)
+        d_stereo = m_stereo.dist(m_stereo.sample(20000), m_stereo.mu0).flatten()
+        q_ref = torch.quantile(d_ref, quantiles)
+        q_stereo = torch.quantile(d_stereo, quantiles)
+        max_rel_diff = ((q_ref - q_stereo).abs() / q_ref.clamp_min(1e-6)).max().item()
+        assert max_rel_diff < 0.05, (
+            f"Stereographic wrapped-normal does not match reference for K={K} (max rel diff {max_rel_diff:.4f})"
+        )
+
+    # Stereographic product manifold: sampling and gaussian_mixture should both work
+    pm_stereo = ProductManifold([(-1.0, 4), (0.0, 4), (1.0, 4)], stereographic=True)
+    torch.manual_seed(42)
+    samples = pm_stereo.sample(50)
+    assert samples.shape == (50, pm_stereo.ambient_dim), "Sample shape mismatch for stereographic product manifold"
+    assert pm_stereo.manifold.check_point(samples), "Stereographic product samples not on manifold"
+
+    X, y = pm_stereo.gaussian_mixture(num_points=100, num_classes=2, seed=42)
+    assert X.shape == (100, pm_stereo.ambient_dim), "gaussian_mixture shape mismatch on stereographic product manifold"
+    assert pm_stereo.manifold.check_point(X), "gaussian_mixture samples not on stereographic product manifold"


### PR DESCRIPTION
## Summary

Fixes #37 — `pm.sample` (and `Manifold.sample`) crashed on stereographic manifolds.

### The crash
Sampling on any stereographic manifold raised a shape mismatch:
```
RuntimeError: The size of tensor a (2) must match the size of tensor b (3) at non-singleton dimension 1
```
`_to_tangent_plane_mu0` prepended an extra ambient coordinate for every non-Euclidean manifold. That's correct for the Lorentz/sphere models (`ambient_dim == dim + 1`), but **wrong for stereographic coordinates**, where `ambient_dim == dim` and the tangent space at the origin is just `R^dim`. The over-sized tangent vector then broke `parallel_transport`.

### The fix
Stereographic manifolds now embed the intrinsic tangent vector without the extra coordinate. They also carry a conformal factor `λ₀ = 2/(1 + κ·‖0‖²) = 2` at the origin (for **every** curvature, including the flat case), so the orthonormal tangent vector is divided by `λ₀`. This isn't just about not crashing — without the `/λ₀` correction the wrapped normal comes out ~2× too wide. After the fix, the **distance-to-origin distribution matches the equivalent non-stereographic manifold** across hyperbolic, flat, and spherical curvatures (max relative quantile diff < 1.3% at 20k samples).

### Tests
Adds `test_stereographic_sampling`, covering single + product stereographic manifolds:
- sampling runs and shapes are correct,
- sampled points lie on the manifold (`check_point`),
- the wrapped-normal distance-to-origin distribution agrees with the non-stereographic reference (intrinsic quantity), and
- `gaussian_mixture` works on a stereographic product manifold.

Full suite (minus the slow HF dataloader job) is green: **40 passed**.

### Out of scope (separate follow-up)
While investigating I found that `Manifold.stereographic()` / `inverse_stereographic()` conversion is **non-isometric for |curvature| ≠ 1** (distance error up to ~2 at κ=0.5; fine at κ=±1). That's a distinct pre-existing bug in the projection scaling, not touched here — happy to file it separately.