### PR TITLE
Fix non-isometric stereographic conversion for non-unit curvature

### DIFF
--- a/manify/manifolds.py
+++ b/manify/manifolds.py
@@ -365,9 +365,11 @@ class Manifold:
     def stereographic(self, *points: Float[torch.Tensor, "n_points n_dim"]) -> tuple[Manifold, ...]:
         r"""Convert the manifold to its stereographic equivalent. If points are given, convert them as well.
 
-        Formula for stereographic projection (for $i \geq 1$):
+        The points lie on the unit hyperboloid/sphere (geoopt uses unit curvature and carries the
+        curvature in the scale), so the unit-curvature projection is rescaled by $R = |K|^{-1/2}$
+        (for $i \geq 1$):
         \begin{equation}
-            \rho_K(x_i) = \frac{x_i}{1 + \sqrt{|K|} \cdot x_0}
+            \rho_K(x_i) = |K|^{-1/2} \cdot \frac{x_i}{1 + x_0}
         \end{equation}
 
         For more information, see https://arxiv.org/pdf/1911.08411
@@ -390,9 +392,12 @@ class Manifold:
         if self.type == "E":
             return stereo_manifold, *points
 
-        # Convert points
-        num = [X[:, 1:] for X in points]
-        denom = [1 + abs(self.curvature) ** 0.5 * X[:, 0:1] for X in points]
+        # Convert points. The points live on the *unit* hyperboloid/sphere (geoopt uses k=1 and lets
+        # the scale carry the curvature), so we apply the unit-curvature projection x_i / (1 + x_0) and
+        # then rescale by R = |K|^{-1/2} to land on the curvature-K stereographic model.
+        scale = abs(self.curvature) ** -0.5
+        num = [scale * X[:, 1:] for X in points]
+        denom = [1 + X[:, 0:1] for X in points]
         for X in denom:
             X[X.abs() < 1e-6] = 1e-6  # Avoid division by zero
         stereo_points = [n / d for n, d in zip(num, denom, strict=False)]
@@ -715,9 +720,11 @@ class ProductManifold(Manifold):
     def stereographic(self, *points: Float[torch.Tensor, "n_points n_dim"]) -> tuple[ProductManifold, ...]:
         r"""Convert the manifold to its stereographic equivalent. If points are given, convert them as well.
 
-        Formula for stereographic projection (for $i \geq 1$):
+        The points lie on the unit hyperboloid/sphere (geoopt uses unit curvature and carries the
+        curvature in the scale), so the unit-curvature projection is rescaled by $R = |K|^{-1/2}$
+        (for $i \geq 1$):
         \begin{equation}
-            \rho_K(x_i) = \frac{x_i}{1 + \sqrt{|K|} \cdot x_0}
+            \rho_K(x_i) = |K|^{-1/2} \cdot \frac{x_i}{1 + x_0}
         \end{equation}
 
         For more information, see https://arxiv.org/pdf/1911.08411

--- a/tests/test_manifolds.py
+++ b/tests/test_manifolds.py
@@ -255,6 +255,58 @@ def test_product_manifold_methods():
         X, y = pm.gaussian_mixture(num_points=100, num_classes=2, seed=42, adjust_for_dims=True)
 
 
+def test_stereographic_conversion_isometry():
+    """Stereographic conversion must preserve distances at every curvature, not just |K| == 1.
+
+    The forward projection used to fold the curvature scale into the denominator, which only matches
+    the correct formula when |K| == 1. For other curvatures the conversion silently distorted
+    distances. This escaped the existing checks in `_shared_tests` because those only run at
+    curvatures -1, 0, and 1. Here we verify, across a range of curvatures, that:
+      * converting to stereographic coordinates preserves pairwise and to-origin distances,
+      * converting back preserves them too, and
+      * the round trip returns the original points.
+    """
+    print("Testing stereographic conversion isometry across curvatures...")
+
+    curvatures = [-2.0, -1.0, -0.5, 0.5, 1.0, 2.0]
+
+    for K in curvatures:
+        print(f"  Testing curvature K = {K}")
+        M = Manifold(K, 4, stereographic=False)
+        torch.manual_seed(0)
+        # Keep the covariance modest so points stay well away from the boundary, where float32 distance
+        # computations get noisy. The curvature-scaling bug is multiplicative, so it is glaringly visible
+        # even at these moderate distances.
+        means = torch.vstack([M.mu0] * 10)
+        covs = torch.stack([torch.eye(M.dim) * 0.1] * 10)
+        X = M.sample(z_mean=means, sigma=covs)
+
+        M_stereo, X_stereo = M.stereographic(X)
+        assert M_stereo.is_stereographic, f"Converted manifold should be stereographic for K={K}"
+        assert M_stereo.manifold.check_point(X_stereo), f"Converted points not on stereographic manifold for K={K}"
+
+        # Forward isometry: distances on the original manifold match distances on the stereographic one.
+        # The buggy formula distorted these by ~0.2-0.25 here for |K| != 1, far above this tolerance.
+        d_orig = M.dist(X, X)
+        d_stereo = M_stereo.dist(X_stereo, X_stereo)
+        assert torch.allclose(d_orig, d_stereo, atol=5e-2), (
+            f"Stereographic conversion is not isometric for K={K} "
+            f"(max diff {(d_orig - d_stereo).abs().max().item():.4f})"
+        )
+
+        # Distances to the origin should be preserved as well
+        d_orig_0 = M.dist(X, M.mu0).flatten()
+        d_stereo_0 = M_stereo.dist(X_stereo, M_stereo.mu0).flatten()
+        assert torch.allclose(d_orig_0, d_stereo_0, atol=5e-2), (
+            f"Distances to origin not preserved under stereographic conversion for K={K}"
+        )
+
+        # Round trip back to the original coordinates
+        M_back, X_back = M_stereo.inverse_stereographic(X_stereo)
+        assert not M_back.is_stereographic, f"Inverse-converted manifold should not be stereographic for K={K}"
+        assert torch.allclose(X_back, X, atol=1e-3), f"Stereographic round trip does not recover points for K={K}"
+
+
 def test_sampling_distances_to_origin():
     """Test that distances to origin follow expected statistical properties."""
     print("Testing distances to origin for wrapped normal distributions...")


### PR DESCRIPTION
## Summary

Follow-up to #42. While fixing stereographic sampling I found that `Manifold.stereographic()` / `ProductManifold.stereographic()` **distort distances for any |curvature| ≠ 1** — the conversion is not an isometry, even though it should be.

### Root cause
The forward projection used denominator `1 + √|K|·x₀`:
```python
denom = [1 + abs(self.curvature) ** 0.5 * X[:, 0:1] for X in points]
stereo = num / denom
```
But the stored points lie on the **unit** hyperboloid/sphere — geoopt uses `k=1` and lets the `Scaled` wrapper carry the curvature. So the correct map is the unit-curvature projection `x_i / (1 + x₀)` rescaled by `R = |K|^{-1/2}`:
```python
scale = abs(self.curvature) ** -0.5
num   = [scale * X[:, 1:] for X in points]
denom = [1 + X[:, 0:1] for X in points]
```
The buggy denominator only equals the correct one when `√|K| = 1`, i.e. |K| = 1 — which is why it went unnoticed.

`inverse_stereographic` already implemented the matching inverse (`x_i = 2√|K|·y_i / (1 + K‖y‖²)`), so the round trip is now isometric in **both** directions for all curvatures. `ProductManifold` delegates per factor and is fixed automatically.

### Why the tests missed it
`_shared_tests` only exercises the stereographic round trip at curvatures `-1, 0, 1` (via `test_manifold_methods`). The bug is invisible at |K| = 1.

### Tests
Adds `test_stereographic_conversion_isometry`, checking forward isometry (pairwise + to-origin distances), round-trip recovery, and on-manifold membership across hyperbolic and spherical curvatures with |K| ≠ 1. Verified it **fails on the old formula** (max distance error ≈ 0.24 at K=−2) and passes on the fix.

Full suite (minus the slow HF dataloader job): **40 passed**.

### Impact / measurements
| curvature | old max Δdist | new max Δdist |
|-----------|--------------:|--------------:|
| ±1.0      | ~0.01 (float) | ~0.01 (float) |
| −2.0      | 0.24          | 0.0005        |
| −0.5      | 0.25          | 0.0007        |
| +2.0      | 0.20          | 0.01          |
| +0.5      | 0.25          | 0.02          |

### Note on stacking
This branches off `main` independently of #42 (different functions). The two touch `tests/test_manifolds.py` in different regions (this one mid-file, #42 at end), so they merge cleanly in either order.