### PR TITLE
Fix packaging: include all manify subpackages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,8 @@ docs = [
   "griffe"
 ]
 
-[tool.setuptools]
-packages = ["manify"]
+[tool.setuptools.packages.find]
+include = ["manify*"]
 
 [tool.setuptools.package-data]
 "manify" = ["../data/**/*"]


### PR DESCRIPTION
pyproject.toml hardcoded [tool.setuptools] packages = ["manify"],
which told setuptools to package only the top-level manify module
(plus manifolds.py) and silently drop clustering, curvature_estimation,
embedders, optimizers, predictors, and utils. Anyone installing from
git or a built wheel got ModuleNotFoundError on import. Switch to
setuptools' automatic package discovery restricted to the manify
namespace so all subpackages are included.

Fixes #45

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012Wi7Cn4kXTBEkPAMgEHjXk