### PR TITLE
Fix mypy CI failure on Python 3.12+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,6 @@ line-ending = "auto"
 [tool.mypy]
 packages = ["manify"]
 exclude = ["manify/optimizers/_adan.py"]  # Use unmodified adan.py code from original repo
-python_version = "3.10"
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 check_untyped_defs = true


### PR DESCRIPTION
## Summary
- CI on `main` was failing the `test (3.12)`, `test (3.13)`, and `test (3.14)` jobs (3.10/3.11 passed) with `mypy manify/` erroring: `numpy/__init__.pyi:737: error: Type statement is only supported in Python 3.12 and greater [syntax]`.
- Root cause: `[tool.mypy]` pinned `python_version = "3.10"`, which forces mypy to validate *all* analyzed syntax — including third-party stub files — against Python 3.10 grammar, regardless of which interpreter is actually running mypy. numpy 2.5.1 (only resolved for Python 3.12+) uses a PEP 695 `type` statement in its bundled stub, which mypy rejects under a 3.10 target.
- Fix: drop the hardcoded `python_version` override. Without it, mypy defaults to the version of the interpreter it's running under — which is already what the CI matrix wants, since each job invokes mypy separately per Python version (3.10 through 3.14).
- This is unrelated to #45 / PR #46 (already merged); it's a separate pre-existing bug that surfaced on `main`'s post-merge CI run.

## Test plan
- [x] Reproduced the exact failure locally in a Python 3.12 venv with numpy 2.5.1 installed (`mypy --python-version 3.10` on a file importing numpy fails with the same error; omitting `--python-version` succeeds)
- [x] Ran `mypy manify/` in that Python 3.12 venv with the fix applied: `Success: no issues found in 33 source files`
- [x] Confirmed the Python 3.10 CI job's behavior is unchanged: without an explicit `python_version`, mypy defaults to the running interpreter's version, which is still 3.10 on that job


---
_Generated by [Claude Code](https://claude.ai/code/session_012Wi7Cn4kXTBEkPAMgEHjXk)_