### PR TITLE
Add configurable dtype to Manifold; float64 avoids high-curvature overflow

### DIFF
--- a/manify/manifolds.py
+++ b/manify/manifolds.py
@@ -33,6 +33,9 @@ class Manifold:
         dim: The dimension of the manifold.
         device: The device on which the manifold is stored.
         stereographic: Whether to use stereographic coordinates.
+        dtype: The floating-point dtype for the origin, sampling, and geometric operations. Defaults to
+            ``torch.float32``. Use ``torch.float64`` for large ``|curvature| * sigma^2 * dim``, where the ambient
+            hyperboloid/sphere coordinates (``cosh``/``sin`` of the tangent norm) otherwise overflow float32.
 
     Attributes:
         curvature: The curvature of the manifold. Negative for hyperbolic, zero for Euclidean, and positive for
@@ -40,6 +43,7 @@ class Manifold:
         dim: The dimension of the manifold.
         device: The device on which the manifold is stored.
         is_stereographic: Whether stereographic coordinates are used for the manifold.
+        dtype: The floating-point dtype used for manifold tensors and operations.
         scale: The scale factor derived from the curvature.
         type: A string identifier for the manifold type ('H' for hyperbolic, 'E' for Euclidean, 'S' for spherical,
             'P' for poincaré ball, 'D' for stereographic sphere).
@@ -49,7 +53,14 @@ class Manifold:
         name: A string identifier for the manifold.
     """
 
-    def __init__(self, curvature: float, dim: int, device: str = "cpu", stereographic: bool = False):
+    def __init__(
+        self,
+        curvature: float,
+        dim: int,
+        device: str = "cpu",
+        stereographic: bool = False,
+        dtype: torch.dtype = torch.float32,
+    ):
         # Device management
         self.device = device
 
@@ -58,6 +69,7 @@ class Manifold:
         self.dim = dim
         self.scale = abs(curvature) ** -0.5 if curvature != 0 else 1
         self.is_stereographic = stereographic
+        self.dtype = dtype
 
         # A couple of manifold-specific quirks we need to deal with here
         if stereographic:
@@ -93,6 +105,11 @@ class Manifold:
                 self.mu0 = torch.Tensor([1.0] + [0.0] * dim).to(self.device).reshape(1, -1)
 
         self.name = f"{self.type}_{abs(self.curvature):.1f}^{dim}"
+
+        # Cast the geoopt manifold (incl. its learnable scale) and the origin to the requested dtype. float64
+        # is needed at large |K|*sigma^2*dim, where the ambient cosh/sin coordinates overflow float32.
+        self.manifold = self.manifold.to(self.dtype)
+        self.mu0 = self.mu0.to(self.dtype)
 
         # Couple of assertions to check
         assert self.manifold.check_point(self.mu0)
@@ -204,7 +221,7 @@ class Manifold:
         Returns:
             tangent_points: Tensor of points in the tangent plane at the origin.
         """
-        x = torch.Tensor(x).reshape(-1, self.dim)
+        x = torch.as_tensor(x, dtype=self.dtype, device=self.device).reshape(-1, self.dim)
         if self.is_stereographic:
             # Stereographic models keep the intrinsic dimension (ambient_dim == dim), so there is no
             # extra coordinate to prepend. The conformal factor at the origin is
@@ -215,7 +232,7 @@ class Manifold:
             return x / 2.0
         if self.type == "E":
             return x
-        return torch.cat([torch.zeros((x.shape[0], 1), device=self.device), x], dim=1)
+        return torch.cat([torch.zeros((x.shape[0], 1), dtype=self.dtype, device=self.device), x], dim=1)
 
     def sample(
         self,
@@ -240,11 +257,11 @@ class Manifold:
             v: Tensor of tangent vectors (if `return_tangent` is True).
         """
         z_mean = self.mu0 if z_mean is None else z_mean
-        z_mean = torch.Tensor(z_mean).reshape(-1, self.ambient_dim).to(self.device)
+        z_mean = torch.as_tensor(z_mean, dtype=self.dtype, device=self.device).reshape(-1, self.ambient_dim)
         n = z_mean.shape[0]
 
-        sigma = torch.stack([torch.eye(self.dim)] * n).to(self.device) if sigma is None else sigma
-        sigma = torch.Tensor(sigma).reshape(-1, self.dim, self.dim).to(self.device)
+        sigma = torch.stack([torch.eye(self.dim, dtype=self.dtype)] * n).to(self.device) if sigma is None else sigma
+        sigma = torch.as_tensor(sigma, dtype=self.dtype, device=self.device).reshape(-1, self.dim, self.dim)
         assert sigma.shape == (
             n,
             self.dim,
@@ -259,7 +276,7 @@ class Manifold:
 
         # Sample initial vector from N(0, sigma)
         N = torch.distributions.MultivariateNormal(
-            loc=torch.zeros((n * n_samples, self.dim), device=self.device), covariance_matrix=sigma
+            loc=torch.zeros((n * n_samples, self.dim), dtype=self.dtype, device=self.device), covariance_matrix=sigma
         )
         v = N.sample()
 
@@ -301,10 +318,10 @@ class Manifold:
         """
         # Default to mu=self.mu0 and sigma=I
         mu = self.mu0 if mu is None else mu
-        mu = torch.Tensor(mu).reshape(-1, self.ambient_dim).to(self.device)
+        mu = torch.as_tensor(mu, dtype=self.dtype, device=self.device).reshape(-1, self.ambient_dim)
         n = mu.shape[0]
-        sigma = torch.stack([torch.eye(self.dim)] * n).to(self.device) if sigma is None else sigma
-        sigma = torch.Tensor(sigma).reshape(-1, self.dim, self.dim).to(self.device)
+        sigma = torch.stack([torch.eye(self.dim, dtype=self.dtype)] * n).to(self.device) if sigma is None else sigma
+        sigma = torch.as_tensor(sigma, dtype=self.dtype, device=self.device).reshape(-1, self.dim, self.dim)
 
         # Euclidean case is regular old Gaussian log-likelihood
         if self.type == "E":
@@ -317,7 +334,7 @@ class Manifold:
         if torch.isnan(v).any():
             print("NANs in parallel transport")
             v = torch.nan_to_num(v, nan=0.0)
-        N = torch.distributions.MultivariateNormal(torch.zeros(self.dim, device=self.device), sigma)
+        N = torch.distributions.MultivariateNormal(torch.zeros(self.dim, dtype=self.dtype, device=self.device), sigma)
         ll = N.log_prob(v[:, 1:])
 
         # For convenience

--- a/tests/test_manifolds.py
+++ b/tests/test_manifolds.py
@@ -1,4 +1,5 @@
 import geoopt
+import pytest
 import torch
 
 from manify.embedders._losses import dist_component_by_manifold  # type: ignore
@@ -493,3 +494,47 @@ def test_stereographic_sampling():
     X, y = pm_stereo.gaussian_mixture(num_points=100, num_classes=2, seed=42)
     assert X.shape == (100, pm_stereo.ambient_dim), "gaussian_mixture shape mismatch on stereographic product manifold"
     assert pm_stereo.manifold.check_point(X), "gaussian_mixture samples not on stereographic product manifold"
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_manifold_dtype_propagation(dtype):
+    """The requested dtype should flow through the origin, sampling, and distance computations."""
+    print(f"Checking dtype propagation for {dtype}...")
+    for curv in [-1.0, 0.0, 1.0]:
+        M = Manifold(curvature=curv, dim=16, dtype=dtype)
+        assert M.dtype == dtype
+        assert M.mu0.dtype == dtype
+
+        X = M.sample(20, sigma=torch.eye(16, dtype=dtype))
+        assert X.dtype == dtype, f"sample dtype mismatch for K={curv}"
+
+        D = M.pdist(X)
+        assert D.dtype == dtype, f"pdist dtype mismatch for K={curv}"
+        assert torch.isfinite(D).all(), f"distances should be finite for K={curv}"
+
+        ll = M.log_likelihood(X)
+        assert ll.dtype == dtype, f"log_likelihood dtype mismatch for K={curv}"
+
+
+def test_float64_avoids_high_curvature_overflow():
+    """Regression: the wrapped-normal sampler must stay finite at large |K| * sigma^2 * dim.
+
+    The ambient hyperboloid/sphere coordinates are cosh/sin of the tangent norm, which scales like
+    sqrt(|K| * sigma^2 * dim). Around sqrt(kappa) ~ 44 those coordinates exceed the float32 range and the
+    sampled points (and hence every distance) become non-finite. float64 pushes that boundary out to
+    sqrt(kappa) ~ 354, covering any realistic dimension.
+    """
+    torch.manual_seed(0)
+    K, dim = -1.0, 4096  # kappa = |K| * 1 * dim = 4096, well past the float32 overflow threshold
+
+    M64 = Manifold(curvature=K, dim=dim, dtype=torch.float64)
+    X64 = M64.sample(n_samples=32, sigma=torch.eye(dim, dtype=torch.float64))
+    assert torch.isfinite(X64).all(), "float64 sample should be finite at high curvature x dimension"
+    D64 = M64.pdist(X64)
+    assert torch.isfinite(D64).all(), "float64 pdist should be finite at high curvature x dimension"
+    assert (D64.triu(1) >= 0).all(), "distances should be non-negative"
+
+    # Document the motivating failure: the same configuration overflows in the default float32.
+    M32 = Manifold(curvature=K, dim=dim)
+    X32 = M32.sample(n_samples=32, sigma=torch.eye(dim))
+    assert not torch.isfinite(X32).all(), "float32 is expected to overflow here, which is why dtype is configurable"


### PR DESCRIPTION
The wrapped-normal sampler builds ambient hyperboloid/sphere coordinates as cosh/sin of the tangent norm, which grows like exp(sqrt(|K|*sigma^2*dim)). In float32 these exceed the dynamic range around sqrt(kappa) ~ 44 (e.g. K=-1, dim=4096), so sample() returns non-finite points and every downstream distance becomes inf/nan.

Add a dtype argument to Manifold (default torch.float32, so existing behavior is unchanged) and thread it through the origin, tangent-plane construction, sampling, and log-likelihood. Passing dtype=torch.float64 pushes the overflow boundary out to sqrt(kappa) ~ 354, covering any realistic dimension.

Tests: dtype propagation across H/E/S and a regression that float64 stays finite at K=-1, dim=4096 while float32 overflows.