### PR TITLE
Ignore PLR0917 (too many positional args), consistent with PLR0913

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ ignore = [
     "E501",   # Line too long (handled by formatter)
     "D107",   # Missing docstring in __init__ (pydocstyle equivalent)
     "PLR0913", # Too many arguments to function call
+    "PLR0917", # Too many positional arguments (consistent with PLR0913; stabilized out of preview in ruff 0.16)
     "PLR0912", # Too many branches
     "PLR0915", # Too many statements
     "PLR2004", # Magic value used in comparison


### PR DESCRIPTION
PLR0917 stabilized out of ruff preview in 0.16 and now flags 20 pre-existing public signatures (embedders, predictors, benchmarks, gaussian_mixture, etc.). The project already ignores its sibling PLR0913 (too many arguments); enforcing PLR0917 while ignoring PLR0913 is inconsistent, and the alternative -- making these established APIs keyword-only -- would be a breaking change. Add PLR0917 to the ignore list so ruff check passes.