### PR TITLE
Propagate manifold dtype through VAE and Siamese embedders

### DIFF
--- a/manify/embedders/siamese.py
+++ b/manify/embedders/siamese.py
@@ -73,11 +73,11 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
 
         # Now we assign
         self.pm = pm
-        self.encoder = encoder
+        self.encoder = encoder.to(device=pm.device, dtype=pm.dtype)
         self.beta = beta
 
         if decoder is not None:
-            self.decoder = decoder
+            self.decoder = decoder.to(device=pm.device, dtype=pm.dtype)
         else:
             self.decoder = torch.nn.Identity()
             self.decoder.requires_grad_(False)
@@ -179,6 +179,8 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
         if self.random_state is not None:
             torch.manual_seed(self.random_state)
 
+        X = torch.as_tensor(X, dtype=self.pm.dtype, device=self.pm.device)
+        D = torch.as_tensor(D, dtype=self.pm.dtype, device=self.pm.device)
         n_samples = len(X)
 
         # Generate all upper triangular pairs using torch
@@ -285,6 +287,7 @@ class SiameseNetwork(BaseEmbedder, torch.nn.Module):
             torch.manual_seed(self.random_state)
 
         # Save the  embeddings
+        X = torch.as_tensor(X, dtype=self.pm.dtype, device=self.pm.device)
         embeddings_list = []
         for i in range(0, len(X), batch_size):
             batch = X[i : i + batch_size]

--- a/manify/embedders/vae.py
+++ b/manify/embedders/vae.py
@@ -87,8 +87,8 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         BaseEmbedder.__init__(self, pm=pm, random_state=random_state, device=device)
 
         # Now we assign
-        self.encoder = encoder.to(device)
-        self.decoder = decoder.to(device)
+        self.encoder = encoder.to(device=device, dtype=pm.dtype)
+        self.decoder = decoder.to(device=device, dtype=pm.dtype)
         self.beta = beta
         self.n_samples = n_samples
         self.reconstruction_loss = (
@@ -309,6 +309,7 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
         if self.random_state is not None:
             torch.manual_seed(self.random_state)
 
+        X = torch.as_tensor(X, dtype=self.pm.dtype, device=self.device)
         my_tqdm = tqdm(total=(burn_in_iterations + training_iterations) * len(X))
         opt = torch.optim.Adam(
             [
@@ -381,6 +382,7 @@ class ProductSpaceVAE(BaseEmbedder, torch.nn.Module):
             torch.manual_seed(self.random_state)
 
         # Save the test embeddings
+        X = torch.as_tensor(X, dtype=self.pm.dtype, device=self.device)
         embeddings_list = []
         for i in range(0, len(X), batch_size):
             x_batch = X[i : i + batch_size]


### PR DESCRIPTION
The float64 default (PR for #48/dtype) regressed the nn-based embedders: user-provided encoders/decoders default to float32 and collided with float64 manifold operations ("expected m1 and m2 to have the same dtype, float != double"). These tests only ever failed locally on the dataset download, so the regression surfaced first in CI.

Cast the encoder/decoder to pm.dtype at construction and coerce fit/transform inputs (X, and D for Siamese) to pm.dtype, matching how the predictors were made dtype-aware.