### PR TITLE
Sample diagonal covariances coordinate-wise (avoid O(dim^3) Cholesky)

### DIFF
--- a/manify/manifolds.py
+++ b/manify/manifolds.py
@@ -275,13 +275,22 @@ class Manifold:
 
         # Adjust for n_points:
         z_mean = torch.repeat_interleave(z_mean, n_samples, dim=0)
-        sigma = torch.repeat_interleave(sigma, n_samples, dim=0)
 
-        # Sample initial vector from N(0, sigma)
-        N = torch.distributions.MultivariateNormal(
-            loc=torch.zeros((n * n_samples, self.dim), dtype=self.dtype, device=self.device), covariance_matrix=sigma
-        )
-        v = N.sample()
+        # Sample initial vector from N(0, sigma). For a (batch of) diagonal covariance we sample
+        # coordinate-wise: the full MultivariateNormal path forms an (n*n_samples, dim, dim) tensor and
+        # Choleskys it -- O(dim^3) time and O(n_samples * dim^2) memory -- which is infeasible at high
+        # dimension. The common isotropic/diagonal wrapped-normal case avoids both.
+        sigma_diag = torch.diagonal(sigma, dim1=-2, dim2=-1)  # (n, dim)
+        if torch.equal(sigma, torch.diag_embed(sigma_diag)):
+            std = sigma_diag.clamp_min(0.0).sqrt().repeat_interleave(n_samples, dim=0)
+            v = torch.randn((n * n_samples, self.dim), dtype=self.dtype, device=self.device) * std
+        else:
+            sigma = torch.repeat_interleave(sigma, n_samples, dim=0)
+            N = torch.distributions.MultivariateNormal(
+                loc=torch.zeros((n * n_samples, self.dim), dtype=self.dtype, device=self.device),
+                covariance_matrix=sigma,
+            )
+            v = N.sample()
 
         # Don't need to adjust normal vectors for the Scaled manifold class in geoopt - very cool!
 

--- a/tests/test_manifolds.py
+++ b/tests/test_manifolds.py
@@ -496,6 +496,40 @@ def test_stereographic_sampling():
     assert pm_stereo.manifold.check_point(X), "gaussian_mixture samples not on stereographic product manifold"
 
 
+def test_sample_diagonal_covariance_scales_to_high_dim():
+    """Diagonal covariance must sample coordinate-wise, not via a full (n_samples, dim, dim) Cholesky.
+
+    The old MultivariateNormal path formed an (n_samples, dim, dim) tensor and Choleskied it, which is
+    O(dim^3) time and O(n_samples * dim^2) memory -- infeasible at dim=4096. The diagonal fast path makes
+    identity/diagonal wrapped-normal sampling cheap at any dimension.
+    """
+    M = Manifold(curvature=-1.0, dim=4096, dtype=torch.float64)
+    X = M.sample(n_samples=128)  # sigma=None -> identity (diagonal)
+    assert X.shape == (128, M.ambient_dim)
+    assert torch.isfinite(X).all()
+    assert M.manifold.check_point(X)
+
+    # An explicit non-identity diagonal covariance takes the same fast path and reproduces its variances.
+    torch.manual_seed(0)
+    d = 6
+    E = Manifold(curvature=0.0, dim=d)  # Euclidean: sampled points equal the tangent draws
+    var = torch.rand(d, dtype=E.dtype) + 0.2
+    Xe = E.sample(n_samples=40_000, sigma=torch.diag(var))
+    assert torch.allclose(Xe.var(0), var, rtol=0.1)
+
+
+def test_sample_full_covariance_fallback():
+    """A dense (non-diagonal) covariance must fall back to the exact full-covariance path."""
+    torch.manual_seed(0)
+    d = 6
+    E = Manifold(curvature=0.0, dim=d)  # Euclidean: sampled points ~ N(0, Sigma)
+    A = torch.randn(d, d, dtype=E.dtype)
+    Sigma = A @ A.T + torch.eye(d, dtype=E.dtype)  # dense SPD
+    X = E.sample(n_samples=40_000, sigma=Sigma)
+    assert torch.isfinite(X).all()
+    assert torch.allclose(torch.cov(X.T), Sigma, atol=0.25)
+
+
 def test_default_dtype_is_float64():
     """Manifold math needs the extra range/precision, so both classes default to float64."""
     assert Manifold(curvature=-1.0, dim=4).dtype == torch.float64


### PR DESCRIPTION
Manifold.sample() built an (n_samples, dim, dim) covariance tensor and Choleskied it via MultivariateNormal -- O(dim^3) time and O(n_samples * dim^2) memory. At dim=4096 with a few hundred samples this needs tens of GB and is effectively unusable (it was pinning machines during high-dimensional experiments).

The wrapped normal almost always uses an isotropic/diagonal covariance. Detect the diagonal case with an exact torch.equal check and sample coordinate-wise (randn * sqrt(diag)), skipping the batched Cholesky entirely; dense covariances still fall back to the full MultivariateNormal path. d=4096 sampling drops from OOM to ~0.6s.

Tests: high-dimensional diagonal sampling stays finite/on-manifold and reproduces the requested per-coordinate variances; a dense SPD covariance still matches via fallback.